### PR TITLE
Work around for race condition in shell step

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OcWatch.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OcWatch.java
@@ -19,6 +19,8 @@ import javax.inject.Inject;
 import java.io.InputStream;
 import java.util.List;
 
+import static com.openshift.jenkins.plugins.pipeline.OcAction.exitStatusRaceConditionBugWorkaround;
+
 public class OcWatch extends AbstractStepImpl {
 
     public static final String FUNCTION_NAME = "_OcWatch";
@@ -111,6 +113,8 @@ public class OcWatch extends AbstractStepImpl {
                         // e.g. "[_OcWatch] Running shell script"
                         QuietTaskListenerFactory.QuietTasklistener quiet = QuietTaskListenerFactory.build(listener);
                         Controller dtc = task.launch(envVars,filePath,launcher,quiet);
+
+                        exitStatusRaceConditionBugWorkaround( dtc, filePath, launcher);
 
                         Integer exitStatus = -1;
                         try {


### PR DESCRIPTION
@gabemontero Might try a fix like this for the exception you are getting.

```
java.io.IOException: corrupted content in /var/lib/jenkins/jobs/qwer/workspace@tmp/durable-129c54bd/pid: java.lang.NumberFormatException: For input string: ""
	at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.pid(BourneShellScript.java:175)
	at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.exitStatus(BourneShellScript.java:187)
	at com.openshift.jenkins.plugins.pipeline.OcAction$Execution.run(OcAction.java:183)
	at com.openshift.jenkins.plugins.pipeline.OcAction$Execution.run(OcAction.java:121)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
	at hudson.security.ACL.impersonate(ACL.java:221)
	at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.NumberFormatException: For input string: ""
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:592)
	at java.lang.Integer.parseInt(Integer.java:615)
	at org.jenkinsci.plugins.durabletask.BourneShellScript$ShellController.pid(BourneShellScript.java:173)
	... 11 more

```