### PR TITLE
Fix openshift.run() error

### DIFF
--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -655,7 +655,7 @@ class OpenShiftDSL implements Serializable {
     public Result idle(Object... args ) { return simplePassthrough( "idle", args ); }
     public Result _import(Object... args ) { return simplePassthrough( "import", args ); }
     public Result policy(Object... args ) { return simplePassthrough( "policy", args ); }
-    public Result run(Object... args ) { return simplePassthrough( "perform", args ); }
+    public Result run(Object... args ) { return simplePassthrough( "run", args ); }
     public Result secrets(Object... args ) { return simplePassthrough( "secrets", args ); }
     public Result tag(Object... args ) { return simplePassthrough( "tag", args ); }
 


### PR DESCRIPTION
This PR resolves issue #17.  Replaces argument perform with run.

**Test Pipeline results**
```
OpenShift Build p2i/createcred-pipeline-2
[Pipeline] node
Running on master in /var/lib/jenkins/jobs/p2i-createcred-pipeline/workspace
[Pipeline] {
[Pipeline] stage
[Pipeline] { (openshift run)
[Pipeline] echo

[Pipeline] _OcContextInit
[Pipeline] _OcContextInit
[Pipeline] readFile
[Pipeline] readFile
[Pipeline] _OcAction
[Pipeline] echo
{
    "operation": "run",
    "actions": [
        {
            "reference": {

            },
            "err": "",
            "verb": "run",
            "cmd": "oc run test-app-jenkins --image=172.30.10.223:5000/p2i/test-app --restart=Never --env OPTS='-vvv -u 1001 --connection local' --env INVENTORY_FILE=inventory --env PLAYBOOK_FILE=test-playbook.yaml --server=https://172.30.0.1:443 --namespace=p2i --token=XXXXX ",
            "out": "pod \"test-app-jenkins\" created",
            "status": 0
        }
    ],
    "status": 0
}
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```

**Pod created from Jenkins Pipeline**
```
jcallen@jcallen ~                                                                             [22:06:41]
> $ oc get pod test-app-jenkins
NAME               READY     STATUS      RESTARTS   AGE
test-app-jenkins   0/1       Completed   0          6m
```

**Logs from pod (as expected)**

```
jcallen@jcallen ~                                                                             [22:06:48]
> $ oc logs test-app-jenkins
Using /opt/app-root/src/ansible.cfg as config file
PLAYBOOK: test-playbook.yaml ***************************************************
1 plays in test-playbook.yaml
PLAY [Hello Ansible - quick start] *********************************************
TASK [setup] *******************************************************************
Using module file /usr/lib/python2.7/site-packages/ansible/modules/core/system/setup.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: default
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857 `" && echo ansible-tmp-1493172011.56-8183191472857="` echo $HOME/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857 `" ) && sleep 0'
<localhost> PUT /tmp/tmpBZlBvk TO /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857/setup.py
<localhost> EXEC /bin/sh -c 'chmod u+x /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857/ /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857/setup.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857/setup.py; rm -rf "/opt/app-root/src/.ansible/tmp/ansible-tmp-1493172011.56-8183191472857/" > /dev/null 2>&1 && sleep 0'
ok: [localhost]
TASK [Hello server] ************************************************************
task path: /opt/app-root/src/test-playbook.yaml:6
Using module file /usr/lib/python2.7/site-packages/ansible/modules/core/commands/command.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: default
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281 `" && echo ansible-tmp-1493172012.92-24091237571281="` echo $HOME/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281 `" ) && sleep 0'
<localhost> PUT /tmp/tmpCbQrjY TO /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281/command.py
<localhost> EXEC /bin/sh -c 'chmod u+x /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281/ /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281/command.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /opt/app-root/src/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281/command.py; rm -rf "/opt/app-root/src/.ansible/tmp/ansible-tmp-1493172012.92-24091237571281/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "cmd": "date",
    "delta": "0:00:00.178335",
    "end": "2017-04-26 02:00:13.510318",
    "invocation": {
        "module_args": {
            "_raw_params": "date",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "warn": true
        },
        "module_name": "command"
    },
    "rc": 0,
    "start": "2017-04-26 02:00:13.331983",
    "stderr": "",
    "stdout": "Wed Apr 26 02:00:13 UTC 2017",
    "stdout_lines": [
        "Wed Apr 26 02:00:13 UTC 2017"
    ],
    "warnings": []
}
PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

```