### PR TITLE
add selector exists; tweak to timeout, try/catch error handling

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -3,139 +3,157 @@
  * but is meant to show actual usage of most of the API.
  */
 
-openshift.withCluster() {
-
-    def saSelector1 = openshift.selector( "serviceaccount" )
-    saSelector1.describe()
-    
-    timeout(8) {
-        def templateSelector = openshift.selector( "template", "mongodb-ephemeral")
-        
-        templateSelector.delete('--ignore-not-found')
-        // secrets are not covered by the oc all qualifier, so have to handle separately
-        openshift.delete('all,secret', '-l', 'template=mongodb-ephemeral-template', '--ignore-not-found')
-        template = openshift.create('https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json').object()
-        
-        // Explore the Groovy object which models the OpenShift template as a Map
-        echo "Template contains ${template.parameters.size()} parameters"
-    
-        // For fun, modify the template easily while modeled in Groovy
-        template.labels["mylabel"] = "myvalue"
-    
-        // Process the modeled template. We could also pass JSON/YAML or a template name instead.
-        // note: -p option for oc process not in the oc version that we currently ship with openshift jenkins images
-        def objectModels = openshift.process( template )//, "-p", "MEMORY_LIMIT=600Mi")
-    
-        // objectModels is a list of objects the template defined, modeled as Groovy objects
-        echo "The template will create ${objectModels.size()} objects"
-    
-        // For fun, modify the objects that have been defined by processing the template
-        for ( o in objectModels ) {
-            o.metadata.labels[ "anotherlabel" ] = "anothervalue"
-        }
-    
-        // Serialize the objects and pass them to the create API.
-        // We could also pass JSON/YAML directly; openshift.create(readFile('some.json'))
-        def created = openshift.create(objectModels)
-    
-        // Create returns a selector which will always select the objects created
-        created.withEach {
-            // Each loop binds the variable 'it' to a selector which selects a single object
-            echo "Created ${it.name()} from template with labels ${it.object().metadata.labels}"
-        }
-    
-        // Filter created objects and create a selector which selects only the new DeploymentConfigs
-        def dcs = created.narrow("dc")
-        echo "Database will run in deployment config: ${dcs.name()}"
-        timeout(5) {
-            // Find a least one pod related to the DeploymentConfig and wait it satisfies a condition
-            dcs.related('pods').untilEach(1) {
-                // untilEach only terminates when each selected item causes the body to return true
-                return it.object().status.phase != 'Pending'
-            }
-        }
-    
-        // Print out all pods created by the DC
-        echo "Template created pods: ${dcs.related('pods').names()}"
-    
-        // Show how we can use labels to select as well
-        echo "Finding dc using labels instead: ${openshift.selector('dc',[mylabel:'myvalue']).names()}"
-    
-        echo "DeploymentConfig description"
-        dcs.describe()
-        echo "DeploymentConfig history"
-        dcs.rollout().history()
-    
-        def rubySelector = openshift.selector("bc", "ruby")
-        def builds
-        try {
-            rubySelector.object()
-            builds = rubySelector.related( "builds" )
-        } catch (Throwable t) {
-            // The selector returned from newBuild will select all objects created by the operation
-            nb = openshift.newBuild( "https://github.com/openshift/ruby-hello-world", "--name=ruby" )
-    
-            // Print out information about the objects created by newBuild
-            echo "newBuild created: ${nb.count()} objects : ${nb.names()}"
+try {
+    timeout(time: 2, unit: 'HOURS') {
+        openshift.withCluster() {
             
-            // Filter non-BuildConfig objects and create selector which will find builds related to the BuildConfig
-            builds = nb.narrow("bc").related( "builds" )
-    
-        }
-    
-        // Raw watch which only terminates when the closure body returns true
-        builds.watch {
-            // 'it' is bound to the builds selector.
-            // Continue to watch until at least one build is detected
-            if ( it.count() == 0 ) {
-                return false
+                def saSelector1 = openshift.selector( "serviceaccount" )
+                saSelector1.describe()
+                
+                def templateSelector = openshift.selector( "template", "mongodb-ephemeral")
+                
+                def exists = templateSelector.exists()
+                
+                def template
+                
+                if (!exists) {
+                    template = openshift.create('https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json').object()
+                } else {
+                    template = templateSelector.object()
+                }
+                
+                // start:  remove when we pull in exists related block above
+                templateSelector.delete('--ignore-not-found')
+                // secrets are not covered by the oc all qualifier, so have to handle separately
+                openshift.delete('all,secret', '-l', 'template=mongodb-ephemeral-template', '--ignore-not-found')
+                
+                template = openshift.create('https://raw.githubusercontent.com/openshift/origin/master/examples/db-templates/mongodb-ephemeral-template.json').object()
+                // end: remove when we pull in exits related block above
+                
+               // Explore the Groovy object which models the OpenShift template as a Map
+                echo "Template contains ${template.parameters.size()} parameters"
+            
+                // For fun, modify the template easily while modeled in Groovy
+                template.labels["mylabel"] = "myvalue"
+            
+                // Process the modeled template. We could also pass JSON/YAML or a template name instead.
+                // note: -p option for oc process not in the oc version that we currently ship with openshift jenkins images
+                def objectModels = openshift.process( template )//, "-p", "MEMORY_LIMIT=600Mi")
+            
+                // objectModels is a list of objects the template defined, modeled as Groovy objects
+                echo "The template will create ${objectModels.size()} objects"
+            
+                // For fun, modify the objects that have been defined by processing the template
+                for ( o in objectModels ) {
+                    o.metadata.labels[ "anotherlabel" ] = "anothervalue"
+                }
+            
+                // Serialize the objects and pass them to the create API.
+                // We could also pass JSON/YAML directly; openshift.create(readFile('some.json'))
+                def created = openshift.create(objectModels)
+            
+                // Create returns a selector which will always select the objects created
+                created.withEach {
+                    // Each loop binds the variable 'it' to a selector which selects a single object
+                    echo "Created ${it.name()} from template with labels ${it.object().metadata.labels}"
+                }
+            
+                // Filter created objects and create a selector which selects only the new DeploymentConfigs
+                def dcs = created.narrow("dc")
+                echo "Database will run in deployment config: ${dcs.name()}"
+                // Find a least one pod related to the DeploymentConfig and wait it satisfies a condition
+                dcs.related('pods').untilEach(1) {
+                    // untilEach only terminates when each selected item causes the body to return true
+                    return it.object().status.phase != 'Pending'
+                }
+            
+                // Print out all pods created by the DC
+                echo "Template created pods: ${dcs.related('pods').names()}"
+            
+                // Show how we can use labels to select as well
+                echo "Finding dc using labels instead: ${openshift.selector('dc',[mylabel:'myvalue']).names()}"
+            
+                echo "DeploymentConfig description"
+                dcs.describe()
+                echo "DeploymentConfig history"
+                dcs.rollout().history()
+            
+                def rubySelector = openshift.selector("bc", "ruby")
+                def builds
+                try {
+                    rubySelector.object()
+                    builds = rubySelector.related( "builds" )
+                } catch (Throwable t) {
+                    // The selector returned from newBuild will select all objects created by the operation
+                    nb = openshift.newBuild( "https://github.com/openshift/ruby-hello-world", "--name=ruby" )
+            
+                    // Print out information about the objects created by newBuild
+                    echo "newBuild created: ${nb.count()} objects : ${nb.names()}"
+                    
+                    // Filter non-BuildConfig objects and create selector which will find builds related to the BuildConfig
+                    builds = nb.narrow("bc").related( "builds" )
+            
+                }
+            
+                // Raw watch which only terminates when the closure body returns true
+                builds.watch {
+                    // 'it' is bound to the builds selector.
+                    // Continue to watch until at least one build is detected
+                    if ( it.count() == 0 ) {
+                        return false
+                    }
+                    // Print out the build's name and terminate the watch
+                    echo "Detected new builds created by buildconfig: ${it.names()}"
+                    return true
+                }
+            
+                echo "Waiting for builds to complete..."
+            
+                // Like a watch, but only terminate when at least one selected object meets condition
+                builds.untilEach {
+                    return it.object().status.phase == "Complete"
+                }
+            
+                // Print a list of the builds which have been created
+                echo "Build logs for ${builds.names()}:"
+            
+                // Find the bc again, and ask for its logs
+                def result = rubySelector.logs()
+            
+                // Each high-level operation exposes stout/stderr/status of oc actions that composed
+                echo "Result of logs operation:"
+                echo "  status: ${result.status}"
+                echo "  stderr: ${result.err}"
+                echo "  number of actions to fulfill: ${result.actions.size()}"
+                echo "  first action executed: ${result.actions[0].cmd}"
+                
+                // The following steps below are geared toward testing of bugs or features that have been introduced
+                // into the openshift client plugin since its initial release
+                
+                // exercise oc run path, including verification of proper handling of groovy cps
+                // var binding (converting List to array)
+                def runargs1 = []
+                runargs1 << "jenkins-second-deployment"
+                runargs1 << "--image=docker.io/openshift/jenkins-2-centos7:latest"
+                runargs1 << "--dry-run"
+                openshift.run(runargs1)
+                
+                // FYI - pipeline cps groovy compile does not allow String[] runargs2 =  {"jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run"}
+                String[] runargs2 = new String[3]
+                runargs2[0] = "jenkins-second-deployment"
+                runargs2[1] = "--image=docker.io/openshift/jenkins-2-centos7:latest"
+                runargs2[2] = "--dry-run"
+                openshift.run(runargs2)
+                
+                openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run")
+                    
+                
+            
             }
-            // Print out the build's name and terminate the watch
-            echo "Detected new builds created by buildconfig: ${it.names()}"
-            return true
-        }
-    
-        echo "Waiting for builds to complete..."
-    
-        // Like a watch, but only terminate when at least one selected object meets condition
-        builds.untilEach {
-            return it.object().status.phase == "Complete"
-        }
-    
-        // Print a list of the builds which have been created
-        echo "Build logs for ${builds.names()}:"
-    
-        // Find the bc again, and ask for its logs
-        def result = rubySelector.logs()
-    
-        // Each high-level operation exposes stout/stderr/status of oc actions that composed
-        echo "Result of logs operation:"
-        echo "  status: ${result.status}"
-        echo "  stderr: ${result.err}"
-        echo "  number of actions to fulfill: ${result.actions.size()}"
-        echo "  first action executed: ${result.actions[0].cmd}"
-        
-        // The following steps below are geared toward testing of bugs or features that have been introduced
-        // into the openshift client plugin since its initial release
-        
-        // exercise oc run path, including verification of proper handling of groovy cps
-        // var binding (converting List to array)
-        def runargs1 = []
-        runargs1 << "jenkins-second-deployment"
-        runargs1 << "--image=docker.io/openshift/jenkins-2-centos7:latest"
-        runargs1 << "--dry-run"
-        openshift.run(runargs1)
-        
-        // FYI - pipeline cps groovy compile does not allow String[] runargs2 =  {"jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run"}
-        String[] runargs2 = new String[3]
-        runargs2[0] = "jenkins-second-deployment"
-        runargs2[1] = "--image=docker.io/openshift/jenkins-2-centos7:latest"
-        runargs2[2] = "--dry-run"
-        openshift.run(runargs2)
-        
-        openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run")
-        
     }
-    
-
+} catch (err) {
+    echo "in catch block"
+    echo "Caught: ${err}"
+    currentBuild.result = 'FAILURE'
+    throw err
 }

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -740,6 +740,25 @@
             </dd>
 
             <dt>
+                <a name="Selector_exists"/>
+                <code>Selector.exists():boolean</code><br></br>
+            </dt>
+            <dd>
+                <p>
+                    <p style="margin-left: 1em; color:#657383;">Example:
+                        <code>
+                            // Returns a boolean whether the template "mongodb-ephemeral is present in the project.<br></br>
+                            def n = openshift.selector( "template", "mongodb-ephemeral" ).exists() <br></br>
+                        </code>
+                    </p>
+                    <br></br>
+                    Returns true if a non-zero number of objects based on the selection criteria exits. In the case of a DynamicSelector,
+                    a query is made to the server to establish existence. In the case of StaticSelectors,
+                    the entire list of objects supplied in the creation of the selector must be present for a return value of "true" to occur.
+                </p>
+            </dd>
+
+            <dt>
                 <a name="Selector_count"/>
                 <code>Selector.count():Integer</code><br></br>
             </dt>
@@ -752,9 +771,8 @@
                         </code>
                     </p>
                     <br></br>
-                    Returns the number of objects the receiver selects. In the case of a DynamicSelector,
-                    a query is made to the server to establish the current count. In the case of StaticSelectors,
-                    this count is a constant (even if the objects it selects do not exist on the server).
+                    Returns the number of objects the receiver selects. For both DynamicSelectors and StaticSelectors,
+                    a query is made to the server to establish the current count.
                 </p>
             </dd>
 


### PR DESCRIPTION
@bparees @jupierce FYI

- eventually, when we pull in a 3.6 `oc` binary into the openshift jenkins image, I'll start the ball rolling the approved version of this pull

- given the current workflow, I'll un-comment the test case change after cutting a new version of the client plugin - don't want to make the new test case available to the overnight tests before the new plugin version is available in the jenkins image (longer term, need to see how we can only expose new test cases once their associated plugin versions are available

Otherwise, comment as desire.  Disclaimer - I don't expect to have say both forms of `exist` survive long term.  I left these various options in to foster discussion.