### PR TITLE
Adding narrow closure and enabling the use of empty static selectors

### DIFF
--- a/examples/coverage.groovy
+++ b/examples/coverage.groovy
@@ -113,6 +113,15 @@ openshift.withCluster('mycluster') {
         echo "  number of actions to fulfill: ${result.actions.size()}"
         echo "  first action executed: ${result.actions[0].cmd}"
 
+        // Empty static / selectors are powerful tools to check the state of the system.
+        // Intentionally create one using a narrow and exercise it.
+        emptySelector = openshift.selector("pods").narrow("bc")
+        openshift.failUnless(!emptySelector.exists()) // Empty selections never exist
+        openshift.failUnless(emptySelector.count() == 0)
+        openshift.failUnless(emptySelector.names().size() == 0)
+        emptySelector.delete() // Should have no impact
+        emptySelector.label(["x":"y"]) // Should have no impact
+
     }
 
     openshift.delete( "project", projectName )

--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -1176,8 +1176,11 @@ class OpenShiftDSL implements Serializable {
                 case "buildconfig" :
                     labels.put( "openshift.io/build-config.name", unqualifiedName );
                     break;
+                case "job" :
+                    labels.put( "job-name", unqualifiedName );
+                    break;
                 default:
-                    throw new AbortException( "Unknown how to find resources related to name: " + k );
+                    throw new AbortException( "Unknown how to find resources related to kind: " + k );
             }
 
             return new OpenShiftResourceSelector("related", kind, labels);


### PR DESCRIPTION
Determined that empty statics are a useful tool to check the system state. Fixing some areas where they throw exceptions unnecessarily. 

Consider:
```
if ( openshift.selector("project").narrow({it.label.x == "y"}).exists() {
    // Previously, if narrow had not found any matches, an exception would have been thrown.
}
```