### PR TITLE
do not allow \r or \n in tokens

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
@@ -20,6 +20,8 @@ public class ClientCommandBuilder implements Serializable {
 
 
     public ClientCommandBuilder(String server, String project, String verb, List verbArgs, List userArgs, List options, List verboseOptions, String token, int logLevel ) {
+        if (token != null && (token.contains("\r") || token.contains("\n")))
+            throw new IllegalArgumentException("tokens cannot contain carriage returns or new lines");
         this.server = server;
         this.project = project;
         this.verb = verb==null?"help":verb;


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-client-plugin/issues/2