### PR TITLE
Don't use a human-readable printer for `oc run` invocation

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -139,6 +139,7 @@ try {
                 runargs1 << "jenkins-second-deployment"
                 runargs1 << "--image=docker.io/openshift/jenkins-2-centos7:latest"
                 runargs1 << "--dry-run"
+                runargs1 << "-o yaml"
                 openshift.run(runargs1)
                 
                 // FYI - pipeline cps groovy compile does not allow String[] runargs2 =  {"jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run"}
@@ -146,6 +147,7 @@ try {
                 runargs2[0] = "jenkins-second-deployment"
                 runargs2[1] = "--image=docker.io/openshift/jenkins-2-centos7:latest"
                 runargs2[2] = "--dry-run"
+                runargs2[3] = "-o yaml"
                 openshift.run(runargs2)
                 
                 openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run")


### PR DESCRIPTION
A bug in the human readable printer implementation means that we need to
ask for a machine readable output from `oc run` in the sample pipeline
so that `oc` versions 3.6+ work correctly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @gabemontero @mfojtik @bparees 

xref: https://github.com/openshift/origin/issues/14821