### PR TITLE
fix the -o yaml fix for oc run --dry-run test

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -143,14 +143,14 @@ try {
                 openshift.run(runargs1)
                 
                 // FYI - pipeline cps groovy compile does not allow String[] runargs2 =  {"jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run"}
-                String[] runargs2 = new String[3]
+                String[] runargs2 = new String[4]
                 runargs2[0] = "jenkins-second-deployment"
                 runargs2[1] = "--image=docker.io/openshift/jenkins-2-centos7:latest"
                 runargs2[2] = "--dry-run"
                 runargs2[3] = "-o yaml"
                 openshift.run(runargs2)
                 
-                openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run")
+                openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run", "-o yaml")
                 
                 // Empty static / selectors are powerful tools to check the state of the system.
                 // Intentionally create one using a narrow and exercise it.


### PR DESCRIPTION
@bparees @stevekuznetsov FYI

we occasionally have a chicken / egg problem wrt testing our changes to the jenkins plugins; we can test plugin changes as part of PR testing, but we can't add new tests until the plugin version has been bumped and the jenkins image updated, since our overnight runs only pick up official images

also, if we change the test, the build config which references https://github.com/openshift/jenkins-client in our test case will pick off master branch and not the specific PR we are testing.

That happened here when I ran @stevekuznetsov test update locally and got an index out of bound error

Here are the changes I employed that allowed to test to run locally.