### PR TITLE
reverse userargs/verbargs to allow cmds like oc rollout status -w

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -150,7 +150,14 @@ try {
                 runargs2[3] = "-o yaml"
                 openshift.run(runargs2)
                 
-                openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest", "--dry-run", "-o yaml")
+                // add this rollout -w test when v0.9.6 is available in our centos image so
+                // the overnight tests pass
+                /*def dc2Selector = openshift.selector("dc", "jenkins-second-deployment")
+                if (dc2Selector.exists()) {
+                    openshift.delete("dc", "jenkins-second-deployment")
+                }
+                openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest")
+                dc2Selector.rollout().status("-w")*/
                 
                 // Empty static / selectors are powerful tools to check the state of the system.
                 // Intentionally create one using a narrow and exercise it.

--- a/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
@@ -69,9 +69,9 @@ public class ClientCommandBuilder implements Serializable {
         cmd.add( toolName );
         cmd.add( verb );
 
-        cmd.addAll( toStringArray(userArgs) );
-
         cmd.addAll( toStringArray(verbArgs) );
+
+        cmd.addAll( toStringArray(userArgs) );
 
         cmd.addAll( toStringArray(options) );
 


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-client-plugin/issues/37

@bparees 

@jupierce - if you got a sec - my local tests are passing for this change, but I wanted to see if you recall some sort of scenario from your original testing that required verbArgs to be in front of userArgs for the ultimate `oc` invocation