### PR TITLE
Add symbol definition for oc tool

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/OpenShiftClientTools.java
+++ b/src/main/java/com/openshift/jenkins/plugins/OpenShiftClientTools.java
@@ -10,6 +10,7 @@ import hudson.tools.ToolDescriptor;
 import hudson.tools.ToolInstallation;
 import hudson.tools.ToolInstaller;
 import hudson.tools.ToolProperty;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
@@ -35,7 +36,7 @@ public class OpenShiftClientTools extends ToolInstallation implements Environmen
         return new OpenShiftClientTools(getName(), translateFor(node, log), getProperties().toList());
     }
 
-    @Extension
+    @Extension @Symbol("oc")
     public static class DescriptorImpl extends ToolDescriptor<OpenShiftClientTools> {
 
         @Override


### PR DESCRIPTION
The plugin cannot be declared as a tool in Declarative Pipeline. The following declaration ends up with an exception:
```
pipeline {
  tools {
    oc 'oc1.5.1'
  }
  ...
}
```
```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: 5: Invalid tool type "oc". Valid tool types: [ant, hudson.tasks.Ant$AntInstallation, org.jenkinsci.plugins.docker.commons.tools.DockerTool, git, hudson.plugins.git.GitTool, gradle, hudson.plugins.gradle.GradleInstallation, jdk, hudson.model.JDK, jgit, org.jenkinsci.plugins.gitclient.JGitTool, jgitapache, org.jenkinsci.plugins.gitclient.JGitApacheTool, maven, hudson.tasks.Maven$MavenInstallation, com.openshift.jenkins.plugins.OpenShiftClientTools] @ line 5, column 9.
           oc 'oc1.5.1'
           ^

1 error

	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1085)
...
```
From the list of types in the exception it's easy to guess what's missing - a declaration of short plugin name.

This PR fixes the issue by adding Symbol annotation in a way similar to other plugins, i.e. [maven](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/tasks/Maven.java#L426).
