### PR TITLE
Put oc on PATH

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/OpenShiftClientTools.java
+++ b/src/main/java/com/openshift/jenkins/plugins/OpenShiftClientTools.java
@@ -36,6 +36,13 @@ public class OpenShiftClientTools extends ToolInstallation implements Environmen
         return new OpenShiftClientTools(getName(), translateFor(node, log), getProperties().toList());
     }
 
+    @Override
+    public void buildEnvVars(EnvVars env) {
+        if (getHome() != null) {
+            env.put("PATH+OC", getHome());
+        }
+    }
+
     @Extension @Symbol("oc")
     public static class DescriptorImpl extends ToolDescriptor<OpenShiftClientTools> {
 


### PR DESCRIPTION
Unfortunately even, when declared inside 'tools' section in Declarative Pipeline, oc tool path doesn't show up on PATH and it needs to be added manually using withEnv expression:
```
pipeline {
    environment {
     OC_PATH = tool('oc1.5.1')
    }
    stages {
        stage("withEnv") {
            steps {
                script {
                    withEnv(['PATH+OC=$OC_PATH']) {
                        openshift.withCluster("cluster1") {
                            echo "${openshift.raw( "version" ).out}"
                        }
                    }
                }
            }
        }
   }
}
```
After applying the change in this PR it can be simplified to:
```
pipeline {
    tools {
        oc 'oc1.5.1'
    }
    stages {
        stage("withoutEnv") {
            steps {
                script {
                    openshift.withCluster("cluster1") {
                        echo "${openshift.raw( "version" ).out}"
                    }
                }
            }
        }
    }
}
```
It looks like saving two lines (and one level of indentation), but it's more then that. First, path to oc is no longer handled manually in the pipeline's code, which is supposed to be declarative, rather then imperative. Second, withEnv() doesn't have to be repeated over and over when openshift plugin is used in multiple stages.

This commit has been inspired by a similar method in [maven plugin](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/tasks/Maven.java#L535).