### PR TITLE
Adding openshift.patch/selector.patch and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,26 +34,26 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Overview
-The [OpenShift](https://www.openshift.com) [Pipeline](https://jenkins.io/solutions/pipeline/) 
-DSL Plugin is a Jenkins plugin which aims to provide a readable, concise, comprehensive, and fluent 
-[Jenkins Pipeline](https://jenkins.io/doc/book/pipeline/) syntax for rich interactions with an OpenShift API Server. The 
+The [OpenShift](https://www.openshift.com) [Pipeline](https://jenkins.io/solutions/pipeline/)
+DSL Plugin is a Jenkins plugin which aims to provide a readable, concise, comprehensive, and fluent
+[Jenkins Pipeline](https://jenkins.io/doc/book/pipeline/) syntax for rich interactions with an OpenShift API Server. The
 plugin leverages an OpenShift command line tool (oc) which must be available on the nodes executing the script
 (options for getting the binary on your nodes can be found [here](#setting-up-jenkins-nodes)).
 
 If you are interested in the legacy Jenkins plugin, you can find it
-[here](https://github.com/openshift/jenkins-plugin).  
+[here](https://github.com/openshift/jenkins-plugin).
 
 ## Reader Prerequisites
 * Familiarity with OpenShift [command line interface](https://docs.openshift.org/latest/cli_reference/basic_cli_operations.html)
-is highly encouraged before exploring the plugin's features. The DSL leverages the [oc](https://docs.openshift.org/latest/cli_reference/index.html) 
+is highly encouraged before exploring the plugin's features. The DSL leverages the [oc](https://docs.openshift.org/latest/cli_reference/index.html)
 binary and, in many cases, passes method arguments directly on to the command line. This document cannot, therefore,
 provide a complete description of all possible OpenShift interactions -- the user may need to reference
 the CLI documentation to find the pass-through arguments a given interaction requires.
-* A fundamental level of understanding of the Jenkins [Pipeline](https://jenkins.io/solutions/pipeline/) architecture and 
+* A fundamental level of understanding of the Jenkins [Pipeline](https://jenkins.io/solutions/pipeline/) architecture and
 [basic pipeline steps](https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/) may be required to appreciate
 the remainder of this document. Readers may also find it useful to understand basic [Groovy syntax](http://groovy-lang.org/syntax.html),
-since pipeline scripts are written using Groovy (Note: Jenkins sandboxes and [interferes](https://issues.jenkins-ci.org/browse/JENKINS-26481) 
-with the use of some Groovy facilities). 
+since pipeline scripts are written using Groovy (Note: Jenkins sandboxes and [interferes](https://issues.jenkins-ci.org/browse/JENKINS-26481)
+with the use of some Groovy facilities).
 
 ## Installing
 This plugin is available at the [Jenkins Update Center](https://updates.jenkins-ci.org/download/plugins/openshift-client/) and is included
@@ -66,7 +66,7 @@ Otherwise, if you are interested in building this plugin locally, follow these s
     ```
     git clone https://github.com/openshift/jenkins-client-plugin.git
     ```
-3. In the root of the local repository, run maven 
+3. In the root of the local repository, run maven
     ```
     cd jenkins-client-plugin
     mvn
@@ -79,18 +79,18 @@ Otherwise, if you are interested in building this plugin locally, follow these s
   4. Find the openshift-client.hpi built in the previous steps.
   5. Submit the file.
   6. Check that Jenkins should be restarted.
- 
-You should now be able to [configure an OpenShift Cluster](#configuring-an-openshift-cluster). 
-Before running a job, you may also need to ensure your Jenkins nodes [have the 'oc' binary](#setting-up-jenkins-nodes) 
+
+You should now be able to [configure an OpenShift Cluster](#configuring-an-openshift-cluster).
+Before running a job, you may also need to ensure your Jenkins nodes [have the 'oc' binary](#setting-up-jenkins-nodes)
 installed.
 
 ## Examples
 
-As the DSL is designed to be intuitive for experienced OpenShift users, the following high level examples 
+As the DSL is designed to be intuitive for experienced OpenShift users, the following high level examples
 may serve to build that intuition before delving into the detailed documentation.
 
 ### Hello, World
-Let's start with a "Hello world" style example. 
+Let's start with a "Hello world" style example.
 
 ```groovy
 /** Use of hostnames and OAuth token values in the DSL is heavily discouraged for maintenance and **/
@@ -106,20 +106,20 @@ openshift.withCluster( 'https://10.13.137.207:8443', 'CO8wPaLV2M2yC_jrm00hCmaz5J
 ### Centralizing Cluster Configuration
 Now let's simplify the first example by moving host, port, token and project information out of the script and into the
 [Jenkins cluster configuration](#configuring-an-openshift-cluster). A single logical name (e.g. "mycluster")
-can now be used to reference these values. This means that if the cluster information changes in the future, your 
+can now be used to reference these values. This means that if the cluster information changes in the future, your
 scripts won't have to!
- 
+
 ```groovy
 /** The logical name references a Jenkins cluster configuration which implies **/
 /** API Server URL, default credentials, and a default project to use within the closure body. **/
 openshift.withCluster( 'mycluster' ) {
     echo "Hello from ${openshift.cluster()}'s default project: ${openshift.project()}"
-    
+
     // But we can easily change project contexts
     openshift.withProject( 'another-project' ) {
         echo "Hello from a non-default project: ${openshift.project()}"
     }
-    
+
     // And even scope operations to other clusters within the same script
     openshift.withCluster( 'myothercluster' ) {
         echo "Hello from ${openshift.cluster()}'s default project: ${openshift.project()}"
@@ -128,9 +128,9 @@ openshift.withCluster( 'mycluster' ) {
 ```
 
 ### Sticking with the defaults
-We can make the previous example even simpler! If you have defined a cluster configuration named 
+We can make the previous example even simpler! If you have defined a cluster configuration named
 "default" or if the Jenkins instance is running within an OpenShift pod, you
-don't need to specify any cluster information. 
+don't need to specify any cluster information.
 
 ```groovy
 openshift.withCluster() { // Use "default" cluster or fallback to OpenShift cluster detection
@@ -139,37 +139,37 @@ openshift.withCluster() { // Use "default" cluster or fallback to OpenShift clus
 ```
 
 ### Introduction to Selectors
-Now a quick introduction to Selectors which allow you to perform operations 
+Now a quick introduction to Selectors which allow you to perform operations
 on a group of API Server objects.
 
 ```groovy
 openshift.withCluster( 'mycluster' ) {
     /** Selectors are a core concept in the DSL. They allow the user to invoke operations **/
     /** on group of objects which satisfy a given criteria. **/
-    
+
     // Create a Selector capable of selecting all service accounts in mycluster's default project
     def saSelector = openshift.selector( 'serviceaccount' )
-    
+
     // Prints `oc describe serviceaccount` to Jenkins console
-    saSelector.describe() 
-    
+    saSelector.describe()
+
     // Selectors also allow you to easily iterate through all objects they currently select.
     saSelector.withEach { // The closure body will be executed once for each selected object.
         // The 'it' variable will be bound to a Selector which selects a single
         // object which is the focus of the iteration.
         echo "Service account: ${it.name()} is defined in ${openshift.project()}"
     }
-    
+
     // Prints a list of current service accounts to the console
     echo "There are ${saSelector.count()} service accounts in project ${openshift.project()}"
     echo "They are named: ${saSelector.names()}"
-    
+
     // Selectors can also be defined using qualified names
     openshift.selector( 'deploymentconfig/frontend' ).describe()
-    
+
     // Or Kind + Label information
     openshift.selector( 'dc', [ tier: 'frontend' ] ).describe()
-    
+
 }
 ```
 
@@ -179,65 +179,65 @@ that new Selectors are regularly returned by DSL operations.
 
 ```groovy
 openshift.withCluster( 'mycluster' ) {
-    // Run `oc new-app https://github.com/openshift/ruby-hello-world` . It 
+    // Run `oc new-app https://github.com/openshift/ruby-hello-world` . It
     // returns a Selector which will select the objects it created for you.
     def created = openshift.newApp( 'https://github.com/openshift/ruby-hello-world' )
-    
+
     // This Selector exposes the same operations you have already seen.
     // (And many more that you haven't!).
     echo "new-app created ${created.count()} objects named: ${created.names()}"
     created.describe()
-    
-    // We can create a Selector from the larger set which only selects 
+
+    // We can create a Selector from the larger set which only selects
     // the build config which new-app just created.
     def bc = created.narrow('bc')
-    
+
     // Let's output the build logs to the Jenkins console. bc.logs()
-    // would run `oc logs bc/ruby-hello-world`, but that might only 
+    // would run `oc logs bc/ruby-hello-world`, but that might only
     // output a partial log if the build is in progress. Instead, we will
     // pass '-f' to `oc logs` to follow the build until it terminates.
     // Arguments to logs get passed directly on to the oc command line.
     def result = bc.logs('-f')
-    
+
     // Many operations, like logs(), return a Result object (even a Selector
     // is a subclass of Result). A Result object contains detailed information about
     // what actions, if any, took place to accomplish an operation.
     echo "The logs operation require ${result.actions.size()} oc interactions"
-    
+
     // You can even see exactly what oc command was executed.
     echo "Logs executed: ${result.actions[0].cmd}"
-    
+
     // And even obtain the standard output and standard error of the command.
     def logsString = result.actions[0].out
     def logsErr = result.actions[0].err
-    
-    // And if after some processing within your pipeline, if you decide 
-    // you need to initiate a new build after the one initiated by 
+
+    // And if after some processing within your pipeline, if you decide
+    // you need to initiate a new build after the one initiated by
     // new-app, simply call the `oc start-build` equivalent:
     def buildSelector = bc.startBuild()
-    buildSelector.logs('-f') 
+    buildSelector.logs('-f')
 }
 ```
 
-### Peer inside of OpenShift objects 
+### Peer inside of OpenShift objects
 
 ```groovy
 openshift.withCluster( 'mycluster' ) {
     def dcs = openshift.newApp( 'https://github.com/openshift/ruby-hello-world' ).narrow('dc')
-    
+
     // dcs is a Selector which selects the deployment config created by new-app. How do
     // we get more information about this DC? Turn it into a Groovy object using object().
     // If there was a chance here that more than one DC was created, we should use objects()
-    // which would return a List of Groovy objects; however, in this example, there 
+    // which would return a List of Groovy objects; however, in this example, there
     // should only be one.
     def dc = dcs.object()
-    
+
     // dc is not a Selector -- It is a Groovy Map which models the content of the DC
     // new-app created at the time object() was called. Changes to the model are not
     // reflected back to the API server, but the DC's content is at our fingertips.
     echo "new-app created a ${dc.kind} with name ${dc.metadata.name}"
     echo "The object has labels: ${dc.metadata.labels}"
-    
+
 }
 ```
 
@@ -248,7 +248,7 @@ Patience is a virtue.
 ```groovy
 openshift.withCluster( 'mycluster' ) {
     def bc = openshift.newApp( 'https://github.com/openshift/ruby-hello-world' ).narrow('bc')
-    
+
     // The build config will create a new build object automatically, but how do
     // we find it? The 'related(kind)' operation can create an appropriate Selector for us.
     def builds = bc.related('builds')
@@ -256,54 +256,54 @@ openshift.withCluster( 'mycluster' ) {
     // There are no guarantees in life, so let's interrupt these operations if they
     // take more than 10 minutes and fail this script.
     timeout(10) {
-    
+
         // We can use watch to execute a closure body each objects selected by a Selector
         // change. The watch will only terminate when the body returns true.
         builds.watch {
             // Within the body, the variable 'it' is bound to the watched Selector (i.e. builds)
             echo "So far, ${bc.name()} has created builds: ${it.names()}"
-            
+
             // End the watch only once a build object has been created.
-            return it.count() > 0   
+            return it.count() > 0
         }
-        
+
         // But we can actually want to wait for the build to complete.
         builds.watch {
             if ( it.count() == 0 ) return false
-            
+
             // A robust script should not assume that only one build has been created, so
             // we will need to iterate through all builds.
             def allDone = true
             it.withEach {
                 // 'it' is now bound to a Selector selecting a single object for this iteration.
                 // Let's model it in Groovy to check its status.
-                def buildModel = it.object() 
+                def buildModel = it.object()
                 if ( it.object().status.phase != "Complete" ) {
                     allDone = false
                 }
             }
-            
+
             return allDone;
         }
-        
-        
-        // Uggh. That was actually a significant amount of code. Let's use untilEach(){} 
+
+
+        // Uggh. That was actually a significant amount of code. Let's use untilEach(){}
         // instead. It acts like watch, but only executes the closure body once
-        // a minimum number of objects meet the Selector's criteria only terminates 
+        // a minimum number of objects meet the Selector's criteria only terminates
         // once the body returns true for all selected objects.
         builds.untilEach(1) { // We want a minimum of 1 build
-        
+
             // Unlike watch(), untilEach binds 'it' to a Selector for a single object.
-            // Thus, untilEach will only terminate when all selected objects satisfy this 
-            // the condition established in the closure body (or until the timeout(10) 
+            // Thus, untilEach will only terminate when all selected objects satisfy this
+            // the condition established in the closure body (or until the timeout(10)
             // interrupts the operation).
-        
+
             return it.object().status.phase == "Complete"
         }
     }
-```    
-    
-     
+```
+
+
 ### Deleting objects. Easy.
 
 ```groovy
@@ -322,7 +322,7 @@ openshift.withCluster( 'mycluster' ) {
 
         // You can use sub-verbs of create for some simple objects
         openshift.create( 'serviceaccount', 'my-service-account' )
-        
+
         // But you want to craft your own, don't you? First,
         // model it with Groovy Maps, Lists, and primitives.
         def secret = [
@@ -333,30 +333,30 @@ openshift.withCluster( 'mycluster' ) {
                     'findme':'please'
                 ]
             ],
-            "stringData": [ 
+            "stringData": [
                 "username": "myname",
                 "password": "mypassword"
             ]
-        ]        
+        ]
 
         // create will marshal the model into JSON and send it to the API server.
         // We will add some passthrough arguments (--save-config and --validate)
         // just for fun.
         def objs = openshift.create( secret, '--save-config', '--validate' )
-        
+
         // create(...) returns a Selector will select the resulting object(s).
         objs.describe()
-        
-        // But, you say, I've already modeled my object in JSON/YAML! It is in 
-        // an SCM or accessible with via HTTP, or..., or ... 
+
+        // But, you say, I've already modeled my object in JSON/YAML! It is in
+        // an SCM or accessible with via HTTP, or..., or ...
         // Don't worry. Just get it to the current Jenkins workspace any way
-        // you want (e.g. using a Jenkins plugin for your SCM). Then read the 
+        // you want (e.g. using a Jenkins plugin for your SCM). Then read the
         // file into a String using normal Jenkins steps.
         def fromJSON = openshift.create( readFile( 'myobjects.json' ) )
-        
+
         // You will get a Selector for the objects created, as always.
         echo "Created objects from JSON file: ${fromJSON.names()}"
-        
+
 }
 ```
 
@@ -367,18 +367,18 @@ openshift.withCluster( 'mycluster' ) {
     def p = openshift.selector( 'pods/mypod' ).object()
     p.metadata.labels['newlabel']='newvalue' // Adjust the model
     openshift.apply(p) // Patch the object on the server
-}   
+}
 ```
 
 ### Can't live without OpenShift templates? No problem.
 
 ```groovy
 openshift.withCluster( 'mycluster' ) {
-    
+
     // One straightforward way is to pass string arguments directly to `oc process`.
     // This includes any parameter values you want to specify.
     def models = openshift.process( "openshift//mongodb-ephemeral", "-p", "MEMORY_LIMIT=600Mi" )
-    
+
     // A list of Groovy object models that were defined in the template will be returned.
     echo "Creating this template will instantiate ${models.size()} objects"
 
@@ -386,7 +386,7 @@ openshift.withCluster( 'mycluster' ) {
     for ( o in models ) {
         o.metadata.labels[ "mylabel" ] = "myvalue"
     }
-    
+
     // You can pass this list of object models directly to the create API
     def created = openshift.create( models )
     echo "The template instantiated: ${models.names()}"
@@ -405,7 +405,7 @@ openshift.withCluster( 'mycluster' ) {
 
     // This model can be specified as the template to process
     openshift.create( openshift.process( template, "-p", "MEMORY_LIMIT=600Mi" ) )
-    
+
 }
 ```
 
@@ -413,34 +413,34 @@ openshift.withCluster( 'mycluster' ) {
 
 ```groovy
 openshift.withCluster( 'devcluster' ) {
-    
+
     def maps = openshift.selector( 'dc', [ microservice: 'maps' ] )
-    
+
     // Model the source objects using the 'exportable' flag to strip cluster
     // specific information from the objects (i.e. like 'oc export').
     def objs = maps.objects( exportable:true )
-    
+
     // Modify the models as you see fit.
     def timestamp = "${System.currentTimeMillis()}"
     for ( obj in objs ) {
         obj.metadata.labels[ "promoted-on" ] = timestamp
     }
-    
+
     openshift.withCluster( 'qecluster' ) {
-    
+
         // Might want Jenkins to ask someone before we do this ;-)
         mail (
             to: 'devops@acme.com',
             subject: "Maps microservice (${env.BUILD_NUMBER}) is awaiting promotion",
              body: "Please go to ${env.BUILD_URL}.");
         input "Ready to update QE cluster with maps microservice?"
-        
-        // Note that the selector is relative to its closure body and 
+
+        // Note that the selector is relative to its closure body and
         // operates on the qecluster now.
         maps.delete( '--ignore-not-present' )
-        
+
         openshift.create( objs )
-        
+
         // Let's wait until at least one pod is Running
         maps.related( 'pods' ).untilEach {
             return it.object().status.phase == 'Running'
@@ -456,7 +456,7 @@ can be used prevent recoverable errors from causing a build to fail.
 
 ```groovy
 openshift.withCluster( 'mycluster' ) {
-    
+
     try {
         openshift.doAs( 'some-invalid-token-value' ) {
             openshift.newProject( 'my-new-project' )
@@ -467,29 +467,29 @@ openshift.withCluster( 'mycluster' ) {
         // about the failure.
         "Error encountered: ${e}"
     }
-    
+
 }
 ```
 
 The error printed out to the Jenkins console would look something like (and yes,
 the token will be masked as shown):
 ```
-Error encountered: hudson.AbortException: new-project returned an error; sub-step failed: 
-{reference={}, err=error: You must be logged in to the server (the server has asked for the client to provide credentials), 
-verb=new-project, cmd=oc my-new-project --skip-config-write --insecure-skip-tls-verify 
+Error encountered: hudson.AbortException: new-project returned an error; sub-step failed:
+{reference={}, err=error: You must be logged in to the server (the server has asked for the client to provide credentials),
+verb=new-project, cmd=oc my-new-project --skip-config-write --insecure-skip-tls-verify
 --server=https://192.168.1.109:8443 --namespace=myproject --token=XXXXX , out=, status=1}
 ```
 
 ### Troubleshooting
 Want to see the details of your OpenShift API Server interactions?
- 
+
 ```groovy
 openshift.withCluster( 'mycluster' ) {
-    
-    openshift.verbose() 
+
+    openshift.verbose()
     // Get details printed to the Jenkins console and pass high --log-level to all oc commands
     openshift.newProject( 'my-new-project' )
-    openshift.verbose(false) // Turn it back 
+    openshift.verbose(false) // Turn it back
 
     // If you want verbose output, but want a specific log-level
     openshift.logLevel(3)
@@ -502,8 +502,8 @@ openshift.withCluster( 'mycluster' ) {
 ### Who are you, really?
 Getting advanced? You might need more than just default credentials associated
 with your cluster. You can leverage any OpenShift Token credential type in the Jenkins
-credential store by passing doAs the credential's identifier. If you think 
-security is a luxury you can live without (it's not), you can also pass doAs 
+credential store by passing doAs the credential's identifier. If you think
+security is a luxury you can live without (it's not), you can also pass doAs
 a raw token value.
 
 ```groovy
@@ -545,7 +545,7 @@ only interact with resources within that cluster? You might not need to do anyth
 Leaving out the cluster name when calling openshift.withCluster will cause
 the plugin to try:
 1. To access a Jenkins cluster configuration named "default" and, if one does not exist..
-2. To assume it is running within an OpenShift Pod with a service account. In this scenario, 
+2. To assume it is running within an OpenShift Pod with a service account. In this scenario,
 the following cluster information will be used:
   * API Server URL: "https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT_HTTPS}"
   * File containing Server Certificate Authority: /run/secrets/kubernetes.io/serviceaccount/ca.crt
@@ -558,10 +558,10 @@ openshift.withCluster() {  // find "default" cluster configuration and fallback 
 }
 ```
 
-If you do need to configure clusters, it is a simple matter. As an authorized 
+If you do need to configure clusters, it is a simple matter. As an authorized
 Jenkins user, navigate to Manage Jenkins -> Configure System -> and find the OpenShift Plugin section.
- 
-Add a new cluster and you should see a form like the following. 
+
+Add a new cluster and you should see a form like the following.
 ![cluster-config](src/readme/images/cluster-config.png)
 
 The cluster "name" (e.g. "mycluster") is the only thing you need to remember when writing scripts.
@@ -574,9 +574,9 @@ openshift.withCluster( 'mycluster' ) {
 ```
 
 ## Setting up Credentials
-To define a new credential for the DSL in the Jenkins credential store, navigate to 
+To define a new credential for the DSL in the Jenkins credential store, navigate to
 Credentials -> System -> Global credentials -> Add Credentials (you can the domain based
-on your particular security requirements). 
+on your particular security requirements).
 
 ![token-config](src/readme/images/token-credential-config.png)
 
@@ -589,10 +589,10 @@ Jenkins PATH environment variable. If your Jenkins nodes are running OpenShift i
 stop reading here: they are already installed!
 
 If your nodes are running outside of OpenShift, you can install the tool on each node
-yourself, or use Jenkins' Tool installer to do it for you. To do this, as authorized 
-Jenkins user, navigate to Manage Jenkins -> Global Tool Configuration -> and find 
+yourself, or use Jenkins' Tool installer to do it for you. To do this, as authorized
+Jenkins user, navigate to Manage Jenkins -> Global Tool Configuration -> and find
 the "OpenShift Client Tools" section.
-  
+
 Here you can define a version of the client tools, where to find them, and if they
 should be automatically instead when a node requires them.
 
@@ -620,12 +620,12 @@ node('agent1') {
 Please refer to Jenkins documentation on Global Tool Configuration which allows, for example,
 Linux and Windows nodes to acquire different builds of a tool.
 
- 
+
 ## You call this documentation?!
 Not exactly. This is a brief overview of some of the capabilities of the plugin. The details
-of the API are embedded within the plugin's online documentation within a running Jenkins instance. 
+of the API are embedded within the plugin's online documentation within a running Jenkins instance.
 To find it:
-1. Create a new Pipeline Item 
+1. Create a new Pipeline Item
 2. Click "Pipeline Syntax" below the DSL text area
 3. On the left navigation menu, click "Global Variables Reference"
 

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -23,12 +23,12 @@
             script. Each method will be documented using the following conventions:
             <p style="margin-left: 1em;">
                 <b>Method with closure:</b>
-                <code>receiver.methodName(requiredParameter:type[, optionalParameter:type]):returnType {…closure body…}</code>
-                <br></br>
+                <code>receiver.methodName(requiredParameter:type, [ optionalParameter:type]):returnType {…closure body…}</code>
+                <br />
                 <b>Method with return value:</b>
-                <code>receiver.methodName(requiredParameter:type[, optionalParameter:type]):returnType</code>
-                <br></br>
-                <br></br>
+                <code>receiver.methodName(requiredParameter:type, [ optionalParameter:type]):returnType</code>
+                <br />
+                <br />
                 Return types will may be standard types (String, List<![CDATA[&lt;]]>String<![CDATA[&gt;]]>, bool, int, etc.) or complex types,
                 specific to this plugin, which have behaviors of their own (e.g. <a href="#Result"><code>Result</code></a>,
                 <a href="#Selector"><code>Selector</code></a>, <a href="#RolloutManager"><code>RolloutManager</code></a>). These return types are
@@ -47,7 +47,7 @@
 
         <dl>
             <a name="openshift_withCluster"/>
-            <dt><code>openshift.withCluster([clusterName:String[, credential:String]]) {…}</code></dt>
+            <dt><code>openshift.withCluster([clusterName:String, [ credential:String]]) {…}</code></dt>
             <dd>
                 <p>
                     Declares that OpenShift operations within the closure body should be executed against the
@@ -55,13 +55,13 @@
                     <a href="#openshift_withProject"><code>openshift.withProject</code></a> (establishing the default project within
                     the closure) and <a href="#openshift_doAs"><code>openshift.doAs</code></a> (establishing the default authorization
                     token within the closure).
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     <code>withCluster</code> may not be contained within a
                     <a href="#openshift_withProject"><code>openshift.withProject</code></a> or
                     <a href="#openshift_doAs"><code>openshift.doAs</code></a> closure.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     When <code>withCluster</code> closures are nested within each other, OpenShift operations will use the
                     clusterName information associated with the most tightly scoped occurrence.
                     <ul>
@@ -69,8 +69,8 @@
                             <b>clusterName</b> - The name of an OpenShift clusterName defined in the global configuration OR a String
                             literal URL (e.g. "https://10.13.137.186:8443"). The special protocol "insecure://" may also be used if https is
                             desired but TLS certificate verification should be disabled.
-                            <br></br>
-                            <br></br>
+                            <br />
+                            <br />
                             Use of the Jenkins global configuration method is highly encouraged as it will insulate your pipeline
                             scripts from changes to your server (e.g. a change in its IP address). It will also allow
                             <code>withCluster</code> to implicitly act as both
@@ -78,8 +78,8 @@
                             the closure) and <a href="#openshift_doAs"><code>openshift.doAs</code></a> (changing the authorization
                             token within the closure) if project and authorization information is associated with the clusterName
                             configuration.
-                            <br></br>
-                            <br></br>
+                            <br />
+                            <br />
                             If the clusterName argument is omitted, the plugin will try to derive clusterName information in the following ways:
                             <ol>
                                 <li>A lookup for a clusterName named "default" in the Jenkins global configuration.</li>
@@ -97,18 +97,33 @@
                 </p>
             </dd>
 
+            <a name="openshift_cluster"/>
+            <dt><code>openshift.cluster():String</code></dt>
+            <dd>
+
+                <p>
+                    <p  style="margin-left: 1em; color:#657383;">
+                        <code>
+                            def clusterUrl = openshift.cluster();<br />
+                            echo "Now using cluster with url $${clusterUrl}"<br />
+                        </code>
+                    </p>
+                    Returns the url of the currently scoped cluster.
+                </p>
+            </dd>
+
             <a name="openshift_doAs"/>
             <dt><code>openshift.doAs(credential:String):Object {…}</code></dt>
             <dd>
                 <p>
                     Specifies that OpenShift operations within the closure body should use the identified credential.
                     The return value is the value returned by (or the value of the last statement within) the closure.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     When <code>doAs</code> closures are nested, OpenShift operations will use the
                     credential information associated with the most tightly scoped occurrence.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     If no credential information is found within a given scope, it is assumed that Jenkins is running
                     within an OpenShift Pod. An attempt will be made to read a token from the Jenkins master
                     filesystem at <b>/run/secrets/kubernetes.io/serviceaccount/token</b>.
@@ -130,20 +145,20 @@
                 <p>
                     <p  style="margin-left: 1em; color:#657383;">
                         <code>
-                            def template = openshift.withProject( 'openshift' ) {<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>openshift.selector('template','mongodb-ephemeral').object()<br></br>
-                            }<br></br>
+                            def template = openshift.withProject('openshift') {<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>openshift.selector('template','mongodb-ephemeral').object()<br />
+                            }<br />
                         </code>
                     </p>
 
                     Specifies that OpenShift operations within the closure body should target the identified project.
                     The return value is the value returned by (or the value of the last statement within) the closure.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     When <code>withProject</code> closures are nested, OpenShift operations will use the
                     project information associated with the most tightly scoped occurrence.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     If no project information is found within a given scope, it is assumed that Jenkins is running
                     within an OpenShift Pod. An attempt will be made to read the current project from the Jenkins master
                     filesystem at <b>/run/secrets/kubernetes.io/serviceaccount/project</b>.
@@ -155,6 +170,20 @@
                 </p>
             </dd>
 
+            <a name="openshift_project"/>
+            <dt><code>openshift.project():String</code></dt>
+            <dd>
+
+                <p>
+                    <p  style="margin-left: 1em; color:#657383;">
+                        <code>
+                            def projectName = openshift.project();<br/>
+                            echo "Now using project $${projectName}"<br/>
+                        </code>
+                    </p>
+                    Returns the name of the currently scoped project.
+                </p>
+            </dd>
 
             <a name="openshift_selector"/>
             <dt>
@@ -165,34 +194,34 @@
                     <code>selector</code> has multiple variations:
                     <ul>
                         <li>
-                            <code>openshift.selector(kind:String):DynamicSelector</code><br></br>
+                            <code>openshift.selector(kind:String):DynamicSelector</code><br />
                             <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.selector("nodes")</code></i>
                         </li>
                         <li>
-                            <code>openshift.selector(kind:String,labels:Map<![CDATA[&lt;]]>String,String<![CDATA[&gt;]]>):DynamicSelector</code><br></br>
+                            <code>openshift.selector(kind:String,labels:Map<![CDATA[&lt;]]>String,String<![CDATA[&gt;]]>):DynamicSelector</code><br />
                             <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.selector("pod", [ alabel : "avalue", l2: "v2" ])</code></i>
                         </li>
                         <li>
-                            <code>openshift.selector(kind:String,name:String):StaticSelector</code><br></br>
+                            <code>openshift.selector(kind:String,name:String):StaticSelector</code><br />
                             <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.selector("dc", "frontend")</code></i>
                         </li>
                         <li>
-                            <code>openshift.selector(qualifiedName:String):StaticSelector</code><br></br>
+                            <code>openshift.selector(qualifiedName:String):StaticSelector</code><br />
                             <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.selector("dc/mysql")</code></i>
                         </li>
                     </ul>
                 </p>
                 <p>
                     <b>Context:</b> Does not need to be contained within <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     Creates a <a href="#Selector">Selector</a> object (either a <a href="#DynamicSelector">DynamicSelector</a> or a
                     <a href="#StaticSelector">StaticSelector</a> depending on the invocation) which can be stored
                     away in a variable or used inline within the DSL. The creation of a Selector does not perform any
                     immediate operation on an OpenShift clusterName -- it merely describes a grouping of objects which
                     can be subsequently be acted on by methods exposed by the Selector object.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     Operations performed using a given Selector will be relative to the context in which those operations
                     are encountered. That is, the context of surrounding
                     <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>,
@@ -224,11 +253,11 @@
 
             <dt>
                 <a name="openshift_create"/>
-                <code>openshift.create(…):StaticSelector</code><br></br>
+                <code>openshift.create(…):StaticSelector</code><br />
                 <a name="openshift_replace"/>
-                <code>openshift.replace(…):StaticSelector</code><br></br>
+                <code>openshift.replace(…):StaticSelector</code><br />
                 <a name="openshift_apply"/>
-                <code>openshift.apply(…):StaticSelector</code><br></br>
+                <code>openshift.apply(…):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
@@ -236,20 +265,20 @@
                     but the same pattern applies to each of these methods:
                     <ul>
                         <li>
-                            <code>openshift.create(obj:Map[, args...:String]):StaticSelector</code><br></br>
-                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create( [ kind : "DeploymentConfig", metadata: [ ... ], ... ] )</code></i>
+                            <code>openshift.create(obj:Map, [ args...:String]):StaticSelector</code><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create([ kind : "DeploymentConfig", metadata: [ ... ], ... ])</code></i>
                         </li>
                         <li>
-                            <code>openshift.create(list:List<![CDATA[&lt;]]>Map<![CDATA[&gt;]]>[, args...:String]):StaticSelector</code><br></br>
-                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create( [ objModel1, objModel1, ... ] )</code></i>
+                            <code>openshift.create(list:List<![CDATA[&lt;]]>Map<![CDATA[&gt;]]>, [ args...:String]):StaticSelector</code><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create([ objModel1, objModel1, ... ])</code></i>
                         </li>
                         <li>
-                            <code>openshift.create(markup:String[, args...:String]):StaticSelector</code><br></br>
+                            <code>openshift.create(markup:String, [ args...:String]):StaticSelector</code><br />
                             <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create("{ \"metadata\" : { ... } ... ")</code></i>
                         </li>
                         <li>
-                            <code>openshift.create(subVerb:String[, args...:String]):StaticSelector</code><br></br>
-                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create( "serviceaccount", "jenkins" )</code></i>
+                            <code>openshift.create(subVerb:String, [ args...:String]):StaticSelector</code><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.create("serviceaccount", "jenkins")</code></i>
                         </li>
                     </ul>
                 </p>
@@ -287,16 +316,16 @@
                     <code>process</code> has multiple variations:
                     <ul>
                         <li>
-                            <code>openshift.process(json:String[,args...:String]):List</code><br></br>
-                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process( "{ \"metadata\": ... }", "-p", "PARAM=VALUE")</code></i><br></br>
-                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process( readFile(file:'template.json'), "-p", "PARAM=VALUE")</code></i>
+                            <code>openshift.process(json:String, [args...:String]):List</code><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process("{ \"metadata\": ... }", "-p", "PARAM=VALUE")</code></i><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process(readFile(file:'template.json'), "-p", "PARAM=VALUE")</code></i>
                         </li>
                         <li>
-                            <code>openshift.process(obj:Map[,args...:String]):List</code><br></br>
-                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process( [ metadata: [... ] ],"-p", "PARAM=VALUE")</code></i>
+                            <code>openshift.process(obj:Map, [args...:String]):List</code><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process([ metadata: [... ] ],"-p", "PARAM=VALUE")</code></i>
                         </li>
                         <li>
-                            <code>openshift.process(templateName:String[,args...:String]):List</code><br></br>
+                            <code>openshift.process(templateName:String, [args...:String]):List</code><br />
                             <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.process("openshift//foo","-p=PARAM=VALUE")</code></i>
                         </li>
                     </ul>
@@ -323,15 +352,49 @@
                 </p>
             </dd>
 
+            <a name="openshift_patch"/>
+            <dt>
+                <code>openshift.patch(…):Result</code>
+            </dt>
+            <dd>
+                <p>
+                    <ul>
+                        <li>
+                            <code>openshift.patch(obj:String, patch:String, [args...:String]):Result</code><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.patch("bc/myBuildConfig", '\'{"spec":{"source":{"git":{"ref": "development"}}}}\'')</code></i><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.patch(readFile('example-buildconfig.yaml'), '\'{"spec":{"source":{"git":{"ref": "development"}}}}\'')</code></i><br />
+                            <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.patch('https://raw.githubusercontent.com/exampleuser/examplerepo/master/example-buildconfig.json', '\'{"spec":{"source":{"git":{"ref": "development"}}}}\'')</code></i><br />
+                        </li>
+                    </ul>
+                </p>
+                <p>
+                    Update field(s) of a resource using strategic merge patch, JSON and YAML formats are accepted.
+                    The patch must be surrounded by escaped quotes, either single or double, depending on what type
+                    of quotes you used to surround your field names and data.
+                    <ul>
+                        <li>
+                            <b>obj</b> - A selector for the resource that you want to patch.
+                        </li>
+                        <li>
+                            <b>patch</b> - The patch to be applied to the resource JSON file, must be quoted.
+                        </li>
+                        <li>
+                            <b>args...</b> - Arguments that will be passed verbatim to the OpenShift process facility.
+                        </li>
+                    </ul>
+                </p>
+            </dd>
+
+
 
             <dt>
                 <a name="openshift_newProject"/>
-                <code>openshift.newProject(name:String[,args...:String]):Result</code><br></br>
+                <code>openshift.newProject(name:String, [args...:String]):Result</code><br />
             </dt>
             <dd>
                 <p>
                     <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.newProject("ruby-temp","--display-name", "Ruby temporary")</code></i>
-                    <br></br>
+                    <br />
                     Creates a new OpenShift project.
                     <ul>
                         <li>
@@ -347,12 +410,12 @@
 
             <dt>
                 <a name="openshift_newApp"/>
-                <code>openshift.newApp(args...:String):StaticSelector</code><br></br>
+                <code>openshift.newApp(args...:String):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
                     <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.newApp("https://github.com/openshift/ruby-hello-world")</code></i>
-                    <br></br>
+                    <br />
                     Invokes the OpenShift new-app facility. The Selector returned identifies the objects created by the request.
                     <ul>
                         <li>
@@ -365,12 +428,12 @@
 
             <dt>
                 <a name="openshift_newBuild"/>
-                <code>openshift.newBuild(args...:String):StaticSelector</code><br></br>
+                <code>openshift.newBuild(args...:String):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
                     <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.newBuild(".","--docker-image=repo/langimage")</code></i>
-                    <br></br>
+                    <br />
                     Invokes the OpenShift new-build facility. The Selector returned identifies the objects created by the request.
                     <ul>
                         <li>
@@ -382,16 +445,16 @@
 
             <dt>
                 <a name="openshift_startBuild"/>
-                <code>openshift.startBuild(args...:String):StaticSelector</code><br></br>
+                <code>openshift.startBuild(args...:String):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
                     <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.startBuild("--from-build=hello-world-1")</code></i>
-                    <br></br>
+                    <br />
                     Invokes the OpenShift start-build facility allowing the caller to specify command line arguments. This invocation
                     differs from the <a href="#Selector_startBuild"><code>Selector.startBuild</code></a> method as
                     the caller to this method must supply the BuildConfig name, if any.
-                    <br></br>
+                    <br />
                     The Selector returned identifies the objects created by the request.
                     <ul>
                         <li>
@@ -404,31 +467,31 @@
 
             <dt>
                 <a name="openshift_exec"/>
-                <code>openshift.exec(args...:String):Result</code><br></br>
+                <code>openshift.exec(args...:String):Result</code><br />
                 <a name="openshift_idle"/>
-                <code>openshift.idle(args...:String):Result</code><br></br>
+                <code>openshift.idle(args...:String):Result</code><br />
                 <a name="openshift_import"/>
-                <code>openshift._import(args...:String):Result</code><br></br>
+                <code>openshift._import(args...:String):Result</code><br />
                 <a name="openshift_policy"/>
-                <code>openshift.policy(args...:String):Result</code><br></br>
+                <code>openshift.policy(args...:String):Result</code><br />
                 <a name="openshift_run"/>
-                <code>openshift.run(args...:String):Result</code><br></br>
+                <code>openshift.run(args...:String):Result</code><br />
                 <a name="openshift_secrets"/>
-                <code>openshift.secrets(args...:String):Result</code><br></br>
+                <code>openshift.secrets(args...:String):Result</code><br />
                 <a name="openshift_set"/>
-                <code>openshift.set(args...:String):Result</code><br></br>
+                <code>openshift.set(args...:String):Result</code><br />
                 <a name="openshift_tag"/>
-                <code>openshift.tag(args...:String):Result</code><br></br>
+                <code>openshift.tag(args...:String):Result</code><br />
                 <a name="openshift_delete"/>
-                <code>openshift.delete(args...:String):Result</code><br></br>
+                <code>openshift.delete(args...:String):Result</code><br />
             </dt>
             <dd>
                 <p>
                     <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.tag("openshift/ruby:2.0", "yourproject/ruby:tip")</code></i>
-                    <br></br>
+                    <br />
                     Several operations: <code>exec</code>, <code>idle</code>, etc. have identical argument signatures and are
                     direct passthroughs to corresponding OpenShift command-line-interface. Each parameter will be passed
-                    verbatim to the command line utility.<br></br>
+                    verbatim to the command line utility.<br />
                     <b>Note:</b> The "import" verb is preceded by an underscore (i.e. openshift._import(...)) because "import" is a reserved word.
                     <ul>
                         <li>
@@ -443,13 +506,13 @@
             <dd>
                 <p>
                     <b>Context:</b> Does not need to be contained within <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     Sets the logging level for all OpenShift operations subsequently executed. The
                     logging level is a global singleton and maintains its value until changed (i.e. it
                     is not affected by scopes like <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     Setting a non-zero logging level increases the output sent to the Jenkins console by this plugin
                     and is also passed as the --loglevel argument to the underlying OpenShift tool.
                     <ul>
@@ -466,8 +529,8 @@
             <dd>
                 <p>
                     <b>Context:</b> Does not need to be contained within <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>.
-                    <br></br>
-                    <br></br>
+                    <br />
+                    <br />
                     Shorthand notation for <a href="#openshift_logLevel"><code>openshift.logLevel</code></a>.
                     <ul>
                         <li>
@@ -484,7 +547,7 @@
             <dd>
                 <p>
                     Allows caller to specify virtually any OpenShift command to execute. Server, project, and token information
-                    will be added automatically by the plugin if they are not specified by the caller.<br></br>
+                    will be added automatically by the plugin if they are not specified by the caller.<br />
                     An exception will be thrown if the command does not return zero for an exit status. The
                     <a href="#Result">Result</a> object returned will make available the stdout and stderr for the operation.
                 </p>
@@ -501,35 +564,35 @@
             Many operations within the OpenShift DSL return a <code>Result</code> object (a Selector is a
             subclass of Result). A Result object details whether a given operation was successful
             and any sub-actions that went into fulfilling the request.
-            <br></br>
+            <br />
             <p  style="padding-left: 1em; color:#657383;">
                 <code>
-                    // Delete all deployment configs<br></br>
-                    def result = openshift.selector( "dc" ).delete()<br></br>
-                    <br></br>
-                    // The name of the operation performed (i.e. "delete")<br></br>
-                    echo "Overall status: $${result.operation}"  <br></br>
-                    <br></br>
-                    // The number of sub-actions run<br></br>
-                    echo "Overall status: $${result.status}"  <br></br>
-                    <br></br>
-                    // First OpenShift command which was executed<br></br>
-                    echo "Actions performed: $${result.actions[0].cmd}" <br></br>
-                    <br></br>
-                    // Additional command reference information<br></br>
-                    echo "Reference information: $${result.actions[0].reference}" <br></br>
-                    <br></br>
-                    // Aggregate output from all sub-actions<br></br>
-                    echo "Operation output: $${result.out}" <br></br>
+                    // Delete all deployment configs<br />
+                    def result = openshift.selector("dc").delete()<br />
+                    <br />
+                    // The name of the operation performed (i.e. "delete")<br />
+                    echo "Overall status: $${result.operation}"  <br />
+                    <br />
+                    // The number of sub-actions run<br />
+                    echo "Overall status: $${result.status}"  <br />
+                    <br />
+                    // First OpenShift command which was executed<br />
+                    echo "Actions performed: $${result.actions[0].cmd}" <br />
+                    <br />
+                    // Additional command reference information<br />
+                    echo "Reference information: $${result.actions[0].reference}" <br />
+                    <br />
+                    // Aggregate output from all sub-actions<br />
+                    echo "Operation output: $${result.out}" <br />
                 </code>
             </p>
         </p>
         <p>
             <b>Context:</b> Accesses to Result fields do not need to be contained within <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>.
-            <br></br>
-            <br></br>
+            <br />
+            <br />
             The Result is effectively a data structure with the following members:
-            <br></br>
+            <br />
             <ul>
                 <li>
                     <code>Result.operation:String</code> - The high level operation that was performed. A high level
@@ -583,22 +646,22 @@
         <p>
             Selectors identify a set of OpenShift resources on which operations can be performed. Consider the
             following example where a selector is created and used:
-            <br></br>
+            <br />
             <p  style="margin-left: 1em; color:#657383;">
                 <code>
-                    def dcSelector = openshift.selector( "dc", [ app : "ruby" ] )  // Selector created<br></br>
-                    def result = dcSelector.describe()   // 'oc describe' run against the selector<br></br>
-                    dcSelector.delete()  // 'oc delete' run against the same selector<br></br>
+                    def dcSelector = openshift.selector("dc", [ app : "ruby" ])  // Selector created<br />
+                    def result = dcSelector.describe()   // 'oc describe' run against the selector<br />
+                    dcSelector.delete()  // 'oc delete' run against the same selector<br />
                 </code>
             </p>
             <a name="StaticSelector"/>
             <a name="DynamicSelector"/>
-            <b>Advanced:</b> <b><code>StaticSelector</code></b> and <b><code>DynamicSelector</code></b> <br></br>
+            <b>Advanced:</b> <b><code>StaticSelector</code></b> and <b><code>DynamicSelector</code></b> <br />
             For many pipelines, it is unnecessary to understand the difference between
             <code>StaticSelector</code> and <code>DynamicSelector</code>. In practice, the two subclasses
             of Selector perform an identical set of operations on the resources they select; however, complex scenarios may
             depend upon the differences in their behavior.
-            <br></br>
+            <br />
             <ul>
                 <li>
                     A <code>StaticSelector</code> contains a fixed set of qualified object names and will only ever
@@ -611,26 +674,26 @@
                     objects depending on the state of the sever.
                 </li>
             </ul>
-            <br></br>
+            <br />
             The <a href="#Selector_freeze"><code>Selector.freeze</code></a> API can be used to convert a
             <code>DynamicSelector</code> into a <code>StaticSelector</code>. Consider the following example:
-            <br></br>
+            <br />
             <p  style="margin-left: 1em; color:#657383;">
                 <code>
-                    // Creates a dynamic selector<br></br>
-                    def secretSelector = openshift.selector( 'secrets' )<br></br>
-                    <br></br>
-                    // Creates a point-in-time, static list of Secret objects<br></br>
-                    def staticSelector = secretSelector.freeze()<br></br>
-                    <br></br>
-                    // Create a new Secret<br></br>
-                    openshift.create( ...new secret named XYZ... )<br></br>
-                    <br></br>
-                    // List will contain XYZ<br></br>
-                    echo "The DynamicSelector found objects: $${secretSelector.names()}"<br></br>
-                    <br></br>
-                    // List will not contain XYZ<br></br>
-                    echo "The StaticSelector found objects: $${staticSelector.names()}"<br></br>
+                    // Creates a dynamic selector<br />
+                    def secretSelector = openshift.selector('secrets')<br />
+                    <br />
+                    // Creates a point-in-time, static list of Secret objects<br />
+                    def staticSelector = secretSelector.freeze()<br />
+                    <br />
+                    // Create a new Secret<br />
+                    openshift.create(...new secret named XYZ...)<br />
+                    <br />
+                    // List will contain XYZ<br />
+                    echo "The DynamicSelector found objects: $${secretSelector.names()}"<br />
+                    <br />
+                    // List will not contain XYZ<br />
+                    echo "The StaticSelector found objects: $${staticSelector.names()}"<br />
                 </code>
             </p>
         </p>
@@ -639,21 +702,21 @@
 
             <dt>
                 <a name="Selector_withEach"/>
-                <code>Selector.withEach {…}</code><br></br>
+                <code>Selector.withEach {…}</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
-                        Example:<br></br>
+                        Example:<br />
                         <code>
-                            def list = openshift.newBuild("...").withEach {<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>// The variable 'it' is bound to a StaticSelector<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>// containing a single name for each iteration <br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>echo "new-build created resource: $${it.name()}"<br></br>
+                            def list = openshift.newBuild("...").withEach {<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>// The variable 'it' is bound to a StaticSelector<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>// containing a single name for each iteration <br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>echo "new-build created resource: $${it.name()}"<br />
                             }
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     Invokes the closure body once for each resource selected by the receiver. Before each iteration,
                     a new <code>StaticSelector</code> will be created which names on a single resource from the
                     selection.
@@ -663,18 +726,18 @@
 
             <dt>
                 <a name="Selector_narrow"/>
-                <code>Selector.narrow(kind:String):StaticSelector</code><br></br>
+                <code>Selector.narrow(kind:String):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
                         Example:
                         <code>
-                            // Creates selector which operates only on the BuildConfig returned by newBuild<br></br>
-                            def bc = openshift.newBuild("...").narrow("bc")<br></br>
+                            // Creates selector which operates only on the BuildConfig returned by newBuild<br />
+                            def bc = openshift.newBuild("...").narrow("bc")<br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     Creates a new Selector by filtering the objects selected by the receiver Selector based on Kind.
                     <ul>
                         <li>
@@ -686,14 +749,14 @@
 
             <dt>
                 <a name="Selector_union"/>
-                <code>Selector.union(sel:Selector):StaticSelector</code><br></br>
+                <code>Selector.union(sel:Selector):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
                         Example: <code>def dcAndBC = openshift.selector("dc").union(openshift.selector('bc'))</code>
                     </p>
-                    <br></br>
+                    <br />
                     Creates a new Selector by adding the objects currently selected by the receiver and the objects
                     currently selected by the argument together. Note that even if both the receiver and the argument
                     are Dynamic Selectors, the result will be Static.
@@ -708,27 +771,27 @@
 
             <dt>
                 <a name="Selector_related"/>
-                <code>Selector.related(kind:String):DynamicSelector</code><br></br>
+                <code>Selector.related(kind:String):DynamicSelector</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
                         Example: <code>
-                                    // Selector will find builds created by BuildConfig<br></br>
-                                    def builds = openshift.newBuild("...").narrow("bc").related("builds")<br></br>
+                                    // Selector will find builds created by BuildConfig<br />
+                                    def builds = openshift.newBuild("...").narrow("bc").related("builds")<br />
                                 </code>
                         Example: <code>
-                                    // Selector will find pods created by DeploymentConfig<br></br>
-                                    def pods = openshift.newApp("...").narrow("dc").related("pods")<br></br>
+                                    // Selector will find pods created by DeploymentConfig<br />
+                                    def pods = openshift.newApp("...").narrow("dc").related("pods")<br />
                                 </code>
                         Example: <code>
-                                    // Selector will find DeploymentConfigs created by a Template<br></br>
-                                    def dcs = openshift.selector("template/xyz").related("dc") <br></br>
+                                    // Selector will find DeploymentConfigs created by a Template<br />
+                                    def dcs = openshift.selector("template/xyz").related("dc") <br />
                                 </code>
                     </p>
-                    <br></br>
+                    <br />
                     Creates a new Selector which finds objects of a specified kind which are related to the object
-                    selected by the receiver. The receiver must only select a single object.<br></br>
+                    selected by the receiver. The receiver must only select a single object.<br />
                     This operation is knows how to find objects related to: DeploymentConfig, Template, and BuildConfig objects.
                     If any other kind is selected by the receiver, an error will be thrown.
                     <ul>
@@ -741,17 +804,17 @@
 
             <dt>
                 <a name="Selector_exists"/>
-                <code>Selector.exists():boolean</code><br></br>
+                <code>Selector.exists():boolean</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">Example:
                         <code>
-                            // Returns a boolean whether the template "mongodb-ephemeral is present in the project.<br></br>
-                            def n = openshift.selector( "template", "mongodb-ephemeral" ).exists() <br></br>
+                            // Returns a boolean whether the template "mongodb-ephemeral is present in the project.<br />
+                            def n = openshift.selector("template", "mongodb-ephemeral").exists() <br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     Returns true if a non-zero number of objects based on the selection criteria exits. In the case of a DynamicSelector,
                     a query is made to the server to establish existence. In the case of StaticSelectors,
                     the entire list of objects supplied in the creation of the selector must be present for a return value of "true" to occur.
@@ -760,17 +823,17 @@
 
             <dt>
                 <a name="Selector_count"/>
-                <code>Selector.count():Integer</code><br></br>
+                <code>Selector.count():Integer</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">Example:
                         <code>
-                            // Returns the number of objects created by newBuild<br></br>
-                            def n = openshift.newBuild("...").count() <br></br>
+                            // Returns the number of objects created by newBuild<br />
+                            def n = openshift.newBuild("...").count() <br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     Returns the number of objects the receiver selects. For both DynamicSelectors and StaticSelectors,
                     a query is made to the server to establish the current count.
                 </p>
@@ -778,35 +841,35 @@
 
             <dt>
                 <a name="Selector_names"/>
-                <code>Selector.names():List<![CDATA[&lt;]]>String<![CDATA[&gt;]]></code><br></br>
+                <code>Selector.names():List<![CDATA[&lt;]]>String<![CDATA[&gt;]]></code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">Example:
                         <code>
-                            // Returns a list of qualified object names created by newBuild<br></br>
-                            def n = openshift.newBuild("...").names() <br></br>
+                            // Returns a list of qualified object names created by newBuild<br />
+                            def n = openshift.newBuild("...").names() <br />
                         </code>
                     </p>
-                    <br></br>
-                    Returns a list of names selected by the receiver (e.g. [ "pods/p1", "pods/p2" ] ).
+                    <br />
+                    Returns a list of names selected by the receiver (e.g. [ "pods/p1", "pods/p2" ]).
                 </p>
             </dd>
 
 
             <dt>
                 <a name="Selector_name"/>
-                <code>Selector.name():String</code><br></br>
+                <code>Selector.name():String</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">Example:
                         <code>
-                            // Return the qualified name of the buildconfig created<br></br>
-                            def n = openshift.newBuild("...").narrow("bc").name()<br></br>
+                            // Return the qualified name of the buildconfig created<br />
+                            def n = openshift.newBuild("...").narrow("bc").name()<br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     Returns the name of the single object selected by the receiver (e.g. "bc/ruby"). This method should
                     only be used if the caller is certain the receiver only selects a single object. If multiple
                     objects are selected, an error is thrown.
@@ -815,25 +878,25 @@
 
             <dt>
                 <a name="Selector_objects"/>
-                <code>Selector.objects([mode:Map]):List<![CDATA[&lt;]]>Map<![CDATA[&gt;]]></code><br></br>
+                <code>Selector.objects([mode:Map]):List<![CDATA[&lt;]]>Map<![CDATA[&gt;]]></code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
-                        Example:<br></br>
+                        Example:<br />
                         <code>
-                            // Returns a list of Maps -- each modeling a selected object<br></br>
-                            def list = openshift.newBuild("...").objects() <br></br>
-                            for ( obj in list ) {<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>echo "newBuild created object of type: $${obj.kind}"<br></br>
-                            }<br></br>
+                            // Returns a list of Maps -- each modeling a selected object<br />
+                            def list = openshift.newBuild("...").objects() <br />
+                            for (obj in list) {<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>echo "newBuild created object of type: $${obj.kind}"<br />
+                            }<br />
                         </code>
                         <code>
-                            // Returns a list of Maps -- each modeling an exportable object<br></br>
-                            def list = openshift.newBuild("...").objects(exportable:true) <br></br>
+                            // Returns a list of Maps -- each modeling an exportable object<br />
+                            def list = openshift.newBuild("...").objects(exportable:true) <br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     The <code>objects</code> method queries for the JSON definition of all objects selected by the
                     receiver and unmarshals that JSON into Groovy Maps. Those Maps are always returned in a list
                     (even if there are zero). The models are simple copies of the API server objects and modifications
@@ -844,26 +907,26 @@
 
             <dt>
                 <a name="Selector_object"/>
-                <code>Selector.object([mode:Map]):Map</code><br></br>
+                <code>Selector.object([mode:Map]):Map</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
-                        Example:<br></br>
+                        Example:<br />
                         <code>
-                            // Returns a model of the buildconfig created by newBuild<br></br>
-                            def obj = openshift.newBuild("...").narrow("bc").object() <br></br>
-                            echo "newBuild created buildconfig: $${obj.metadata.name}"<br></br>
+                            // Returns a model of the buildconfig created by newBuild<br />
+                            def obj = openshift.newBuild("...").narrow("bc").object() <br />
+                            echo "newBuild created buildconfig: $${obj.metadata.name}"<br />
                         </code>
                         <code>
-                            // Returns an exportable model of the buildconfig created by newBuild<br></br>
-                            def obj = openshift.newBuild("...").narrow("bc").object(exportable:true)<br></br>
+                            // Returns an exportable model of the buildconfig created by newBuild<br />
+                            def obj = openshift.newBuild("...").narrow("bc").object(exportable:true)<br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     The <code>object</code> method queries for the JSON definition of the singular object selected by the
                     receiver and unmarshals that JSON into a Groovy Map. The model is a simple copy of the API server
-                    object and modifications are not reflected back to the server.<br></br>
+                    object and modifications are not reflected back to the server.<br />
                     This method should only be used if the caller is certain the receiver selects a single object. If multiple
                     objects are selected, an error is thrown.
 
@@ -873,7 +936,7 @@
 
             <dt>
                 <a name="Selector_freeze"/>
-                <code>Selector.freeze():StaticSelector</code><br></br>
+                <code>Selector.freeze():StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
@@ -884,7 +947,7 @@
 
             <dt>
                 <a name="Selector_logs"/>
-                <code>Selector.logs(args...:String):Result</code><br></br>
+                <code>Selector.logs([args...:String]):Result</code><br />
             </dt>
             <dd>
                 <p>
@@ -892,7 +955,7 @@
                     <code>Result</code> object and also streamed to the Jenkins console.
                     <ul>
                         <li>
-                            <b>args...</b> - A optional list of arguments which will be appended directly to the logs invocation.
+                            <b>args...</b> - An optional list of arguments which will be appended directly to the logs invocation.
                         </li>
                     </ul>
                 </p>
@@ -901,7 +964,7 @@
 
             <dt>
                 <a name="Selector_describe"/>
-                <code>Selector.describe(args...:String):Result</code><br></br>
+                <code>Selector.describe([args...:String]):Result</code><br />
             </dt>
             <dd>
                 <p>
@@ -909,7 +972,7 @@
                     <code>Result</code> object and also streamed to the Jenkins console.
                     <ul>
                         <li>
-                            <b>args...</b> - A optional list of arguments which will be appended directly to the describe invocation.
+                            <b>args...</b> - An optional list of arguments which will be appended directly to the describe invocation.
                         </li>
                     </ul>
                 </p>
@@ -918,14 +981,14 @@
 
             <dt>
                 <a name="Selector_delete"/>
-                <code>Selector.delete([args...:String]):Result</code><br></br>
+                <code>Selector.delete([args...:String]):Result</code><br />
             </dt>
             <dd>
                 <p>
                     Deletes the objects selected by the receiver.
                     <ul>
                         <li>
-                            <b>args...</b> - A optional list of arguments which will be appended directly to the delete invocation.
+                            <b>args...</b> - An optional list of arguments which will be appended directly to the delete invocation.
                         </li>
                     </ul>
                 </p>
@@ -933,24 +996,24 @@
 
             <dt>
                 <a name="Selector_label"/>
-                <code>Selector.label(labels:Map,[args...:String]):Result</code><br></br>
+                <code>Selector.label(labels:Map, [args...:String]):Result</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
-                        Example:<br></br>
+                        Example:<br />
                         <code>
-                            openshift.selector("pods").label( [ k1:'v1', k2:'v2' ], "--overwrite" )<br></br>
+                            openshift.selector("pods").label([ k1:'v1', k2:'v2' ], "--overwrite")<br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     Adds the specified labels to the objects selected by the receiver.
                     <ul>
                         <li>
-                            <b>labels</b> - A map of labels to apply (e.g. [ label1 : 'value1', label2 : 'value2' ] )
+                            <b>labels</b> - A map of labels to apply (e.g. [ label1 : 'value1', label2 : 'value2' ])
                         </li>
                         <li>
-                            <b>args...</b> - A optional list of arguments which will be appended directly to the label invocation.
+                            <b>args...</b> - An optional list of arguments which will be appended directly to the label invocation.
                         </li>
                     </ul>
                 </p>
@@ -958,7 +1021,7 @@
 
             <dt>
                 <a name="Selector_startBuild"/>
-                <code>Selector.startBuild([args...:String]):StaticSelector</code><br></br>
+                <code>Selector.startBuild([args...:String]):StaticSelector</code><br />
             </dt>
             <dd>
                 <p>
@@ -966,11 +1029,11 @@
                     objects, <a href="#Selector_narrow"><code>Selector.narrow</code></a> should be used before this operation
                     if heterogeneous objects can be returned by the receiver. If non-BuildConfig objects are encountered,
                     the OpenShift tool will return an error and the overall operation will fail.
-                    <br></br>
+                    <br />
                     The Selector returned identifies the objects created by the request.
                     <ul>
                         <li>
-                            <b>args...</b> - A optional list of arguments which will be appended directly to the
+                            <b>args...</b> - An optional list of arguments which will be appended directly to the
                             start-build invocation. Any arguments will supplement the BuildConfig name which will be
                             supplied automatically by the receiver.
                         </li>
@@ -981,46 +1044,70 @@
 
             <dt>
                 <a name="Selector_autoscale"/>
-                <code>Selector.autoscale([args...:String):Result // Use on DCs</code><br></br>
+                <code>Selector.autoscale([args...:String):Result // Use on DCs</code><br />
                 <a name="Selector_cancelBuild"/>
-                <code>Selector.cancelBuild([args...:String]):Result  // Use on BCs and Builds</code><br></br>
+                <code>Selector.cancelBuild([args...:String]):Result  // Use on BCs and Builds</code><br />
                 <a name="Selector_deploy"/>
-                <code>Selector.deploy([args...:String):Result // Use on DCs</code><br></br>
+                <code>Selector.deploy([args...:String):Result // Use on DCs</code><br />
                 <a name="Selector_expose"/>
-                <code>Selector.expose([args...:String):Result // Use on Services</code><br></br>
+                <code>Selector.expose([args...:String):Result // Use on Services</code><br />
                 <a name="Selector_scale"/>
-                <code>Selector.scale([args...:String):Result // Use on DCs and RCs</code><br></br>
+                <code>Selector.scale([args...:String):Result // Use on DCs and RCs</code><br />
                 <a name="Selector_volume"/>
-                <code>Selector.volume([args...:String):Result // Use on DCs</code><br></br>
+                <code>Selector.volume([args...:String):Result // Use on DCs</code><br />
             </dt>
             <dd>
                 <p>
                     This group of methods executes one action for each object selected by the receiver.
                     Some of these operations only work on a particular object Kind, so it may be necessary
                     to <a href="#Selector_narrow"><code>narrow</code></a> a Selector before calling one of these
-                    methods.<br></br>
+                    methods.<br />
                     For example, <code>cancelBuild</code> will invoke oc cancel-build once for each object
                     selected by the receiver. It will report an error (causing an exception in the DSL) if
-                    it executes against anything other than a BuildConfig or Build kind.<br></br>
+                    it executes against anything other than a BuildConfig or Build kind.<br />
                     The arguments specified for the method are passed through to each invocation of the
                     associated OpenShift verb. The arguments should not contain the object's name since it
-                    will be included automatically by the API prior to invoke the OpenShift CLI tool.<br></br>
+                    will be included automatically by the API prior to invoke the OpenShift CLI tool.<br />
                     Each of these operations return a <a href="#Result"><code>Result</code></a> which can be
                     examined for information about stdout/stderr/exit status.
                     <ul>
                         <li>
-                            <b>args...</b> - A optional list of arguments which will be appended directly to the
+                            <b>args...</b> - An optional list of arguments which will be appended directly to the
                             invocation.
                         </li>
                     </ul>
                 </p>
             </dd>
 
-
+            <a name="Selector_patch"/>
+            <dt>
+                <code>Selector.patch(patch:String, [args...:String]):Result</code>
+            </dt>
+            <dd>
+                <p style="margin-left: 1em; color:#657383;">
+                  <code>
+                  def bcSelector = openshift.selector("bc", "example-buildconfig")<br />
+                  bcSelector.patch('\'{"spec":{"source":{"git":{"ref": "development"}}}}\'')
+                  </code>
+                </p>
+                <p>
+                    Update field(s) of a resource using strategic merge patch, JSON and YAML formats are accepted.
+                    The patch must be surrounded by escaped quotes, either single or double, depending on what type
+                    of quotes you used to surround your field names and data.
+                    <ul>
+                        <li>
+                            <b>patch</b> - The patch to be applied to the resource JSON file, must be quoted.
+                        </li>
+                        <li>
+                            <b>args...</b> - Arguments that will be passed verbatim to the OpenShift process facility.
+                        </li>
+                    </ul>
+                </p>
+            </dd>
 
             <dt>
                 <a name="Selector_rollout"/>
-                <code>Selector.rollout():RolloutManager</code><br></br>
+                <code>Selector.rollout():RolloutManager</code><br />
             </dt>
             <dd>
                 <p>
@@ -1028,40 +1115,40 @@
                     rollout-related operations on the objects selected by the receiver. If the receiver is a
                     <a href="#DynamicSelector"><code>DynamicSelector</code></a>, the RolloutManager will
                     perform a dynamic selection to satisfy each operation.
-                    <br></br>
+                    <br />
                 </p>
             </dd>
 
 
             <dt>
                 <a name="Selector_watch"/>
-                <code>Selector.watch {…}</code><br></br>
+                <code>Selector.watch {…}</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
-                        Example:<br></br>
+                        Example:<br />
                         <code>
-                            // Create a new buildconfig<br></br>
-                            def nb = openshift.newBuild("https://github.com/openshift/ruby-hello-world", "--name=ruby") <br></br>
-                            def buildSelector = nb.narrow("bc").related("builds")<br></br>
-                            timeout(5) { // Throw exception after 5 minutes<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>buildSelector.watch {<br></br>
+                            // Create a new buildconfig<br />
+                            def nb = openshift.newBuild("https://github.com/openshift/ruby-hello-world", "--name=ruby") <br />
+                            def buildSelector = nb.narrow("bc").related("builds")<br />
+                            timeout(5) { // Throw exception after 5 minutes<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>buildSelector.watch {<br />
                             <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]><![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>return (it.count() > 0)
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>}<br></br>
-                            }<br></br>
-                            echo "Builds have been created: $${buildSelector.names()}"<br></br>
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>}<br />
+                            }<br />
+                            echo "Builds have been created: $${buildSelector.names()}"<br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     The <code>watch</code> method listens for any changes from the objects selected by the receiver.
                     The closure body will be executed at least once before any changes have been detected. Any
                     subsequent watch events will re-invoke the body. Within the body, the <code>it</code> variable
-                    will be bound to the receiver <code>Selector</code>.<br></br>
+                    will be bound to the receiver <code>Selector</code>.<br />
                     The watch body must return a boolean: <code>true</code> to exit the watch or <code>false</code>
-                    to continue it.<br></br>
+                    to continue it.<br />
                     The author is encouraged to wrap this operation in a pipeline <code>timeout</code> step since there is no
-                    guarantee the body will be executed again after the first invocation.<br></br>
+                    guarantee the body will be executed again after the first invocation.<br />
                     If the API server gracefully disconnects the watch connection (e.g. due to watch inactivity),
                     the step will automatically and transparently reestablish the watch and re-invoke the body
                     in case changes took place during the disconnected interval.
@@ -1070,33 +1157,33 @@
 
             <dt>
                 <a name="Selector_untilEach"/>
-                <code>Selector.untilEach([minimumCount:Integer=1) {…}</code><br></br>
+                <code>Selector.untilEach([minimumCount:Integer=1) {…}</code><br />
             </dt>
             <dd>
                 <p>
                     <p style="margin-left: 1em; color:#657383;">
-                        Example:<br></br>
+                        Example:<br />
                         <code>
                             // Create a new buildconfig
-                            def nb = openshift.newBuild("https://github.com/openshift/ruby-hello-world", "--name=ruby") <br></br>
-                            def buildSelector = nb.narrow("bc").related("builds")<br></br>
-                            timeout(5) { // Throw exception after 5 minutes<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>buildSelector.untilEach(1) {<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]><![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>return (it.object().status.phase == "Complete")<br></br>
-                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>}<br></br>
-                            }<br></br>
-                            echo "Builds have been completed: $${buildSelector.names()}"<br></br>
+                            def nb = openshift.newBuild("https://github.com/openshift/ruby-hello-world", "--name=ruby") <br />
+                            def buildSelector = nb.narrow("bc").related("builds")<br />
+                            timeout(5) { // Throw exception after 5 minutes<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>buildSelector.untilEach(1) {<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]><![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>return (it.object().status.phase == "Complete")<br />
+                            <![CDATA[&nbsp;&nbsp;&nbsp;&nbsp;]]>}<br />
+                            }<br />
+                            echo "Builds have been completed: $${buildSelector.names()}"<br />
                         </code>
                     </p>
-                    <br></br>
+                    <br />
                     The <code>untilEach</code> provides a simple interface to ensure that all objects selected by
-                    a receiver meet a user defined condition.<br></br>
+                    a receiver meet a user defined condition.<br />
                     Like <code>watch</code>, <code>untilEach</code> listens for any changes from the objects
                     selected by the receiver. When the number of objects is greater-than or equal to the
-                    minimumCount parameter (defaults to 1), the body will be executed for each object.<br></br>
+                    minimumCount parameter (defaults to 1), the body will be executed for each object.<br />
                     The <code>it</code> variable will be bound to a <code>Selector</code> for the single object to analyze
                     with the body invocation. If the selected object satisfies the user's condition, the body should
-                    return true; if it does not, the body should return false.<br></br>
+                    return true; if it does not, the body should return false.<br />
                     <code>untilEach</code> will not terminate until the number of objects selected by the receiver
                     is greater-than or equal to the minimumCount and the closure body returns true for each
                     selected object.
@@ -1116,15 +1203,15 @@
             against a set of selected resources. A RolloutManager is created using
             <a href="#Selector_rollout"><code>Selector.rollout</code></a> . Before acquiring a <code>RolloutManager</code>,
             callers should ensure their <code>Selector</code> contains only appropriate resources (i.e. DeploymentConfigs).
-            <br></br>
+            <br />
             <p  style="margin-left: 1em; color:#657383;">
                 <code>
-                    def dcSelector = openshift.selector( "dc", [ app : "ruby" ] )  // Selector created<br></br>
-                    // Create a RolloutManager which will act on all objects selected by the receiver<br></br>
-                    def rm = dcSelector.rollout()   <br></br>
-                    def result = rm.history() // Gather history for the selected rollouts<br></br>
-                    echo "DeploymentConfig history:\n$${result.out}"<br></br>
-                    rm.pause() // Pause the selected rollouts<br></br>
+                    def dcSelector = openshift.selector("dc", [ app : "ruby" ])  // Selector created<br />
+                    // Create a RolloutManager which will act on all objects selected by the receiver<br />
+                    def rm = dcSelector.rollout()   <br />
+                    def result = rm.history() // Gather history for the selected rollouts<br />
+                    echo "DeploymentConfig history:\n$${result.out}"<br />
+                    rm.pause() // Pause the selected rollouts<br />
                 </code>
             </p>
         </p>
@@ -1133,25 +1220,25 @@
 
             <dt>
                 <a name="RolloutManager_history"/>
-                <code>RolloutManager.history([args...:String]):Result</code><br></br>
+                <code>RolloutManager.history([args...:String]):Result</code><br />
                 <a name="RolloutManager_latest"/>
-                <code>RolloutManager.latest([args...:String]):Result</code><br></br>
+                <code>RolloutManager.latest([args...:String]):Result</code><br />
                 <a name="RolloutManager_pause"/>
-                <code>RolloutManager.pause([args...:String]):Result</code><br></br>
+                <code>RolloutManager.pause([args...:String]):Result</code><br />
                 <a name="RolloutManager_resume"/>
-                <code>RolloutManager.resume([args...:String]):Result</code><br></br>
+                <code>RolloutManager.resume([args...:String]):Result</code><br />
                 <a name="RolloutManager_status"/>
-                <code>RolloutManager.status([args...:String]):Result</code><br></br>
+                <code>RolloutManager.status([args...:String]):Result</code><br />
                 <a name="RolloutManager_undo"/>
-                <code>RolloutManager.undo([args...:String]):Result</code><br></br>
+                <code>RolloutManager.undo([args...:String]):Result</code><br />
             </dt>
             <dd>
                 <p>
                     <i style="margin-left: 1em; color:#657383;">Example: <code>openshift.selector("dc/nginx").rollout().undo("--to-revision=3")</code></i>
-                    <br></br>
+                    <br />
                     Several <code>RolloutManager</code> operations: <code>history</code>, <code>latest</code>, etc. have identical argument signatures and are
                     direct passthroughs to corresponding OpenShift command-line-interface. Each parameter will be passed
-                    verbatim to the command line utility.<br></br>
+                    verbatim to the command line utility.<br />
                     <ul>
                         <li>
                             <b>args...</b> - A list of arguments which will be sent verbatim to the OpenShift tool.


### PR DESCRIPTION
Adds openshift.patch() and <selector>.patch commands (Fixes #62)

Reformats and refactors various bits of code and documentation (including line endings and extraneous white space)