### PR TITLE
Deprecating doAs in favor of withCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ can be used prevent recoverable errors from causing a build to fail.
 openshift.withCluster( 'mycluster' ) {
 
     try {
-        openshift.doAs( 'some-invalid-token-value' ) {
+        openshift.withCredentials( 'some-invalid-token-value' ) {
             openshift.newProject( 'my-new-project' )
             // ...
         }
@@ -523,22 +523,25 @@ openshift.withCluster( 'mycluster' ) {
 ### Who are you, really?
 Getting advanced? You might need more than just default credentials associated
 with your cluster. You can leverage any OpenShift Token credential type in the Jenkins
-credential store by passing doAs the credential's identifier. If you think
-security is a luxury you can live without (it's not), you can also pass doAs
+credential store by passing withCredentials the credential's identifier. If you think
+security is a luxury you can live without (it's not), you can also pass withCredentials
 a raw token value.
+
+Note: doAs() has been deprecated in favor of withCredentials(), but is currently
+still supported for use in existing scripts
 
 ```groovy
 openshift.withCluster( 'mycluster' ) {
-    openshift.doAs( 'my-normal-credential-id' ) {
+    openshift.withCredentials( 'my-normal-credential-id' ) {
         ...
     }
 
-    openshift.doAs( 'my-privileged-credential-id' ) {
+    openshift.withCredentials( 'my-privileged-credential-id' ) {
         ...
     }
 
     // Raw token value. Not recommended.
-    openshift.doAs( 'CO8wPaLV2M2yC_jrm00hCmaz5Jgw...' ) {
+    openshift.withCredentials( 'CO8wPaLV2M2yC_jrm00hCmaz5Jgw...' ) {
         ...
     }
 }
@@ -602,7 +605,7 @@ on your particular security requirements).
 ![token-config](src/readme/images/token-credential-config.png)
 
 This token can then be selected as the default token for a given Jenkins configuration
-cluster OR used tactically in the DSL with openshift.doAs( 'my-privileged-credential-id' ) {...} .
+cluster OR used tactically in the DSL with openshift.withCredentials( 'my-privileged-credential-id' ) {...} .
 
 ## Setting up Jenkins Nodes
 Each Jenkins node (master/agents) must have a copy of the OpenShift command line tool (oc) installed and in the

--- a/examples/jenkins-withcredentials-sample.groovy
+++ b/examples/jenkins-withcredentials-sample.groovy
@@ -1,0 +1,114 @@
+/**
+ * This script demonstrates the usage of
+ * openshift.doAs and openshift.withCredentials
+ * This script assumes the following setup:
+ *  Environment:
+ *      username: userone
+ *          project: userone
+ *      username: usertwo
+ *          project: usertwo
+ *  And that the credentials are setup correctly
+ *  in Jenkins under the userone account
+ */
+try {
+    timeout(time: 20, unit: 'MINUTES') {
+        // Select the default cluster
+        echo "Selecting the default cluster"
+        openshift.withCluster() {
+            //Select the default user
+            echo "Logging in as the default user (userone) using withCredentials"
+            openshift.withCredentials() {
+                // Select the default project (userone)
+                try {
+                    echo "Selecting the default project (userone)"
+                    openshift.withProject() {
+                        // Create a nodejs application
+                        // This should succeed
+                        echo "This should succeed"
+                        openshift.create('https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json')
+                    }
+                } catch (err) {
+                    echo "in catch block"
+                    echo "Caught: ${err}"
+                }
+                // Try creating an application in usertwo
+                try {
+                    echo "Selecting project (usertwo)"
+                    openshift.withProject('usertwo') {
+                        // This should fail
+                        echo "This should fail"
+                        openshift.create('https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json')
+                    }
+                } catch (err) {
+                    echo "in catch block"
+                    echo "Caught: ${err}"
+                }
+            }
+            // Provide the credentials for usertwo
+            echo "Logging in as usertwo using withCredentials"
+            openshift.withCredentials('usertwo') {
+                // Create an application in usertwo
+                echo "Selecting project usertwo"
+                openshift.withProject('usertwo') {
+                    // This should succeed now
+                    try {
+                        echo "This should succeed now"
+                        openshift.create('https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs-mongodb.json')
+                    } catch (err) {
+                        echo "in catch block"
+                        echo "Caught: ${err}"
+                    }
+                }
+            }
+            // Switch back to the default user (userone)
+            echo "Logging in as user userone using doAs"
+            openshift.doAs('userone') {
+                // Select the default project again (userone)
+                echo "Selecting project userone"
+                openshift.withProject('userone') {
+                    // Create a rails application in userone
+                    try {
+                        // This should succeed
+                        echo "This should succeed"
+                        openshift.create('https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json')
+                    } catch (err) {
+                        echo "in catch block"
+                        echo "Caught: ${err}"
+                    }
+                }
+                // Try creating the application in usertwo
+                echo "Selecting project usertwo"
+                openshift.withProject('usertwo') {
+                    // This should fail
+                    try {
+                        echo "This should fail"
+                        openshift.create('https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json')
+                    } catch (err) {
+                        echo "in catch block"
+                        echo "Caught: ${err}"
+                    }
+                }
+            }
+            // Switch back to userTwo using doAs
+            echo "Logging in as usertwo using doAs"
+            openshift.doAs('usertwo') {
+                // Select usertwo
+                echo "Selecting project usertwo"
+                openshift.withProject('usertwo') {
+                    // Create a rails application in usertwo
+                    try {
+                        // This should succeed now
+                        echo "This should succeed now"
+                        openshift.create('https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json')
+                    } catch (err) {
+                        echo "in catch block"
+                        echo "Caught: ${err}"
+                    }
+                }
+            }
+        }
+    }
+} catch (err) {
+    echo "in catch block"
+    echo "Caught: ${err}"
+}

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -53,13 +53,13 @@
                     Declares that OpenShift operations within the closure body should be executed against the
                     specified clusterName. The statement also implicitly acts as both a
                     <a href="#openshift_withProject"><code>openshift.withProject</code></a> (establishing the default project within
-                    the closure) and <a href="#openshift_doAs"><code>openshift.doAs</code></a> (establishing the default authorization
+                    the closure) and <a href="#openshift_withCredentials"><code>openshift.withCredentials</code></a> (establishing the default authorization
                     token within the closure).
                     <br />
                     <br />
                     <code>withCluster</code> may not be contained within a
                     <a href="#openshift_withProject"><code>openshift.withProject</code></a> or
-                    <a href="#openshift_doAs"><code>openshift.doAs</code></a> closure.
+                    <a href="#openshift_withCredentials"><code>openshift.withCredentials</code></a> closure.
                     <br />
                     <br />
                     When <code>withCluster</code> closures are nested within each other, OpenShift operations will use the
@@ -75,7 +75,7 @@
                             scripts from changes to your server (e.g. a change in its IP address). It will also allow
                             <code>withCluster</code> to implicitly act as both
                             <a href="#openshift_withProject"><code>openshift.withProject</code></a> (changing the target project within
-                            the closure) and <a href="#openshift_doAs"><code>openshift.doAs</code></a> (changing the authorization
+                            the closure) and <a href="#openshift_withCredentials"><code>openshift.withCredentials</code></a> (changing the authorization
                             token within the closure) if project and authorization information is associated with the clusterName
                             configuration.
                             <br />
@@ -125,16 +125,25 @@
                     Returns true if SkipTLSVerify is set for the server connection, false otherwise.
                 </p>
             </dd>
-
             <a name="openshift_doAs"/>
-            <dt><code>openshift.doAs(credential:String):Object {…}</code></dt>
+             <dt><code>openshift.doAs(credential:String):Object {…}</code></dt>
+            <dd>
+                <p>
+                  DEPRECATED: See <a href="#openshift_withCredentials">openshift.withCredentials</a>
+
+                  doAs() has been deprecated in favor of withCredentials(), but is currently
+                  still supported for use in existing scripts.
+                </p>
+            </dd>
+            <a name="openshift_withCredentials"/>
+            <dt><code>openshift.withCredentials(credential:String):Object {…}</code></dt>
             <dd>
                 <p>
                     Specifies that OpenShift operations within the closure body should use the identified credential.
                     The return value is the value returned by (or the value of the last statement within) the closure.
                     <br />
                     <br />
-                    When <code>doAs</code> closures are nested, OpenShift operations will use the
+                    When <code>withCredentials</code> closures are nested, OpenShift operations will use the
                     credential information associated with the most tightly scoped occurrence.
                     <br />
                     <br />
@@ -244,7 +253,7 @@
                     are encountered. That is, the context of surrounding
                     <a href="#openshift_withCluster"><code>openshift.withCluster</code></a>,
                     <a href="#openshift_withProject"><code>openshift.withProject</code></a>,
-                    <a href="#openshift_doAs"><code>openshift.doAs</code></a> closures. For example, a Selector
+                    <a href="#openshift_withCredentials"><code>openshift.withCredentials</code></a> closures. For example, a Selector
                     can be established once and subsequently used within a variety of
                     <code>openshift.withCluster</code> closures. Each time a method
                     is invoked on the Selector, the clusterName affected will differ depending on the


### PR DESCRIPTION
Adding withCredentials to replicate the withCluster and
withProject syntax more closely.  Updated doAs to run through
the new withCredentials method for backwards compatibility.

Also did some general cleanup including spelling and indentation,
updated the documentation and the README with the new syntax.
Also updated dieIfWithout to be dieIfNotWithin (which makes more
grammatical sense I think)