### PR TITLE
Fixes order of flags when using rsh

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -73,9 +73,9 @@ try {
                 // Find a least one pod related to the DeploymentConfig and wait it satisfies a condition
                 dcs.related('pods').untilEach(1) {
                     // some example debug of the pod in question
-                    // commented out until v1.0.3 of the plugin is in the openshift jenkins image 
+                    // commented out until v1.0.3 of the plugin is in the openshift jenkins image
                     //shortname = it.object().metadata.name
-                    //echo openshift.rsh("${shortname}", "hostname").out
+                    //echo openshift.rsh("${shortname}", "ps ax").out
                     // untilEach only terminates when each selected item causes the body to return true
                     return it.object().status.phase != 'Pending'
                 }
@@ -177,14 +177,12 @@ try {
                 openshift.failUnless(emptySelector.names().size() == 0)
                 emptySelector.delete() // Should have no impact
                 emptySelector.label(["x":"y"]) // Should have no impact
-                
+
                 // sanity check for latest and cancel
                 // commented out until v1.0.3 of the plugin is available in the openshift jenkins centos image
                 //dc2Selector.rollout().latest()
                 //sleep 3 SECONDS
                 //dc2Selector.rollout().cancel()
-                
-
             }
         }
     }

--- a/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
+++ b/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
@@ -63,12 +63,12 @@ public class ClusterConfig extends AbstractDescribableImpl<ClusterConfig>
     }
 
     public boolean isSkipTlsVerify() {
-        return skipTlsVerify;
+        return this.skipTlsVerify;
     }
 
     @DataBoundSetter
-    public void setSkipTlsVerify(boolean skipTlsVerify) {
-        this.skipTlsVerify = skipTlsVerify;
+    public void setSkipTlsVerify(boolean skipTLSVerify) {
+        this.skipTlsVerify = skipTLSVerify;
     }
 
     public String getDefaultProject() {

--- a/src/main/java/com/openshift/jenkins/plugins/freestyle/CreateStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/freestyle/CreateStep.java
@@ -39,8 +39,7 @@ public class CreateStep extends BaseStep {
             public boolean perform(String markupFilename) throws IOException,
                     InterruptedException {
                 return standardRunOcCommand(build, listener, "create",
-                        toList("-f", markupFilename), toList(), toList(),
-                        toList());
+                        toList("-f", markupFilename), toList(), toList());
             }
         });
     }

--- a/src/main/java/com/openshift/jenkins/plugins/freestyle/DeleteStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/freestyle/DeleteStep.java
@@ -51,7 +51,7 @@ public class DeleteStep extends BaseStep {
             base.add("--ignore-not-found");
         }
         return standardRunOcCommand(build, listener, "delete", base, toList(),
-                toList(), toList());
+                toList());
     }
 
     @Extension

--- a/src/main/java/com/openshift/jenkins/plugins/freestyle/RawStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/freestyle/RawStep.java
@@ -22,11 +22,11 @@ public class RawStep extends BaseStep {
         this.command = command;
         this.arguments = arguments;
     }
-    
+
     public String getCommand() {
         return command;
     }
-    
+
     public String getCommand(Map<String, String> overrides) {
         return getOverride(getCommand(), overrides);
     }
@@ -49,7 +49,7 @@ public class RawStep extends BaseStep {
             public boolean perform(String markupFilename) throws IOException,
                     InterruptedException {
                 return standardRunOcCommand(build, listener, getCommand(overrides),
-                        toList(getArguments(overrides)), toList(), toList(), toList());
+                        toList(getArguments(overrides)), toList(), toList());
             }
         });
     }

--- a/src/main/java/com/openshift/jenkins/plugins/freestyle/WatchStep.java
+++ b/src/main/java/com/openshift/jenkins/plugins/freestyle/WatchStep.java
@@ -95,7 +95,7 @@ public class WatchStep extends BaseStep {
                                         // true-positive feedback.
             final StringBuffer totalOutput = new StringBuffer();
             runOcCommand(build, listener, "get", base, toList(), toList(),
-                    toList(), new OcProcessRunner() {
+                    new OcProcessRunner() {
 
                         @Override
                         public boolean perform(ProcessBuilder pb)

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OcAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OcAction.java
@@ -38,12 +38,12 @@ public class OcAction extends AbstractStepImpl {
     private final HashMap<String, String> reference;
 
     @DataBoundConstructor
-    public OcAction(String server, String project, String verb, List verbArgs,
-            List userArgs, List options, List verboseOptions, String token,
+    public OcAction(String server, String project, boolean skipTLSVerify, String caPath,
+            String verb, List advArgs, List verbArgs, List userArgs, List options, String token,
             String streamStdOutToConsolePrefix,
             HashMap<String, String> reference, int logLevel) {
-        this.cmdBuilder = new ClientCommandBuilder(server, project, verb,
-                verbArgs, userArgs, options, verboseOptions, token, logLevel);
+        this.cmdBuilder = new ClientCommandBuilder(server, project, skipTLSVerify, caPath,
+                verb, advArgs, verbArgs, userArgs, options, token, logLevel);
         this.verbose = (logLevel > 0);
         this.streamStdOutToConsolePrefix = streamStdOutToConsolePrefix;
         // Reference is used to output information about, for example, file

--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OcWatch.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OcWatch.java
@@ -35,11 +35,11 @@ public class OcWatch extends AbstractStepImpl {
     private final ClientCommandBuilder cmdBuilder;
 
     @DataBoundConstructor
-    public OcWatch(String server, String project, String verb, List verbArgs,
-            List userArgs, List options, List verboseOptions, String token,
+    public OcWatch(String server, String project, boolean skipTLSVerify, String caPath, String verb, List advArgs, List verbArgs,
+            List userArgs, List options, String token,
             int logLevel) {
-        this.cmdBuilder = new ClientCommandBuilder(server, project, verb,
-                verbArgs, userArgs, options, verboseOptions, token, logLevel);
+        this.cmdBuilder = new ClientCommandBuilder(server, project, skipTLSVerify, caPath, verb,
+                advArgs, verbArgs, userArgs, options, token, logLevel);
     }
 
     @Extension

--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -87,7 +87,7 @@ class OpenShiftDSL implements Serializable {
         private String credentialsId;
         private String serverUrl;
         private String serverCertificateAuthorityPath;
-        private Boolean skipTlsVerify;
+        private Boolean skipTLSVerify;
         private String project;
         private ContextId id;
 
@@ -191,21 +191,20 @@ class OpenShiftDSL implements Serializable {
             return ClusterConfig.getHostClusterApiServerUrl();
         }
 
-        public void setServerUrl(String serverUrl, boolean skipTlsVerify) {
+        public void setServerUrl(String serverUrl, boolean skipTLSVerify) {
             this.@serverUrl = Util.fixEmptyAndTrim(serverUrl);
-            this.@skipTlsVerify = skipTlsVerify;
+            this.@skipTLSVerify = skipTLSVerify;
         }
 
-        public boolean isSkipTlsVerify() {
-            if (this.@skipTlsVerify != null) {
-                return this.@skipTlsVerify;
+        public boolean isSkipTLSVerify() {
+            if (this.@skipTLSVerify != null) {
+                return this.@skipTLSVerify;
             }
             if (parent != null) {
-                return parent.isSkipTlsVerify();
+                return parent.isSkipTLSVerify();
             }
             return false;
         }
-
     }
 
     /**
@@ -246,13 +245,16 @@ class OpenShiftDSL implements Serializable {
         }
     }
 
-
     public String project() {
         return currentContext.getProject();
     }
 
     public String cluster() {
         return currentContext.getServerUrl();
+    }
+
+    public boolean skipTLSVerify() {
+        return currentContext.isSkipTLSVerify();
     }
 
     /**
@@ -301,7 +303,7 @@ class OpenShiftDSL implements Serializable {
                 context.setServerCertificateAuthorityContent(cc.getServerCertificateAuthority());
                 context.setCredentialsId(cc.credentialsId);
                 context.setProject(cc.defaultProject);
-                context.setServerUrl(cc.getServerUrl(), cc.isSkipTlsVerify());
+                context.setServerUrl(cc.getServerUrl(), cc.isSkipTLSVerify());
             }
 
             if (credentialId != null) {
@@ -366,27 +368,18 @@ class OpenShiftDSL implements Serializable {
             optionsBase.addAll(overrideArgs);
         }
 
-        List verboseOptionsBase = []
-        if (currentContext.isSkipTlsVerify()) {
-            optionsBase.add("--insecure-skip-tls-verify");
-        } else {
-            String caPath = currentContext.getServerCertificateAuthorityPath()
-            if (caPath != null) {
-                verboseOptionsBase.add("--certificate-authority=" + currentContext.getServerCertificateAuthorityPath());
-            }
-        }
-
         ArrayList<String> userArgsList = (userArgsArray==null)?new ArrayList<String>():Arrays.asList(userArgsArray);
 
         // These arguments will be mapped, by name, to the constructor parameters of OcAction
         Map args = [
                 server:currentContext.getServerUrl(),
                 project:(getProject ? currentContext.getProject() : null),
+                skipTLSVerify: currentContext.isSkipTLSVerify(),
+                caPath: currentContext.getServerCertificateAuthorityPath(),
                 verb:verb,
                 verbArgs:verbArgs,
                 userArgs:userArgsList,
                 options:optionsBase,
-                verboseOptions: verboseOptionsBase,
                 token:currentContext.getToken(),
                 logLevel:logLevel
            ]

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -112,6 +112,20 @@
                 </p>
             </dd>
 
+            <a name="openshift_skiptlsverify"/>
+            <dt><code>openshift.skipTLSVerify():Boolean</code></dt>
+            <dd>
+
+                <p>
+                    <p  style="margin-left: 1em; color:#657383;">
+                        <code>
+                            echo "SkipTLSVerify is set to $${openshift.skipTLSVerify()}"<br />
+                        </code>
+                    </p>
+                    Returns true if SkipTLSVerify is set for the server connection, false otherwise.
+                </p>
+            </dd>
+
             <a name="openshift_doAs"/>
             <dt><code>openshift.doAs(credential:String):Object {…}</code></dt>
             <dd>


### PR DESCRIPTION
Corrects the order of the flags in buildCommonArgs to place
--insecure-skip-tls-verify before the userArgs

Fixes #82