### PR TITLE
protect from presence of ad hoc .kube/config files

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OcAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OcAction.java
@@ -208,6 +208,10 @@ public class OcAction extends AbstractStepImpl {
                         .println(
                                 "Consider removing those options from startBuild and using the logs() command to follow the build output.");
             }
+            
+            // explicitly set KUBECONFIG such that use of this plugin in a non-openshift pod will not pick up a rogue .kube/config
+            // when we fork `oc`; for now, using the default setting when running in a openshift pod (presuming that is safe enough)
+            envVars.put("KUBECONFIG", "/var/lib/origin/openshift.local.config/master/admin.kubeconfig");
 
             try {
                 final DurableTask task;


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-client-plugin/issues/89

@openshift/sig-developer-experience fyi

@elconas - if you think you would have the cycles, I can attach an hpi file with this change for you to try prior to merging / cutting a new version of the plugin - thanks