### PR TITLE
Allowing exceptions to escape watch

### DIFF
--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -1185,7 +1185,8 @@
                     subsequent watch events will re-invoke the body. Within the body, the <code>it</code> variable
                     will be bound to the receiver <code>Selector</code>.<br />
                     The watch body must return a boolean: <code>true</code> to exit the watch or <code>false</code>
-                    to continue it.<br />
+                    to continue it. <br/>
+                    If the closure body throws an exception, the watch will terminate and the exception will be propagated.<br />
                     The author is encouraged to wrap this operation in a pipeline <code>timeout</code> step since there is no
                     guarantee the body will be executed again after the first invocation.<br />
                     If the API server gracefully disconnects the watch connection (e.g. due to watch inactivity),
@@ -1223,9 +1224,10 @@
                     The <code>it</code> variable will be bound to a <code>Selector</code> for the single object to analyze
                     with the body invocation. If the selected object satisfies the user's condition, the body should
                     return true; if it does not, the body should return false.<br />
-                    <code>untilEach</code> will not terminate until the number of objects selected by the receiver
-                    is greater-than or equal to the minimumCount and the closure body returns true for each
-                    selected object.
+                    If the closure body throws an exception, <code>untilEach</code> will terminate and the exception will be propagated.<br />
+                    Unless an exception is thrown by the closure, <code>untilEach</code> will not terminate
+                    until the number of objects selected by the receiver is greater-than or equal to the minimumCount
+                    and the closure body returns true for each selected object.
                 </p>
             </dd>
 


### PR DESCRIPTION
@stevekuznetsov found that exceptions where being consumed by the watch body. This leads to a few concerns:
- timeout{} blocks can't terminate a watch as various points of execution by interrupting the thread.
- The user cannot easily throw an exception inside of a watch to intentionally stop the pipeline (in the current implementation, they would need to try to stop it three times with the error() step).
- The automatic retry may cause the user code to perform some non-idempotent action twice inside the watch body.

In general, I think having the user code try{}catch{} inside the watch body if they don't want it to terminate gives us the fewest unintended consequences. 

Disclaimer: Just some suggestions, so I've done no testing.