### PR TITLE
Add annotate to OpenShift DSL

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -21,6 +21,11 @@ try {
                 // Output the url of the currently selected cluster
                 echo "Using project ${openshift.project()} in cluster with url ${openshift.cluster()}"
 
+                // Test selector.annotate
+                //def railsTemplate = openshift.create("https://raw.githubusercontent.com/openshift/rails-ex/master/openshift/templates/rails-postgresql.json")
+                //railsTemplate.annotate([key1:"value1", key2:"value2"])
+                //railsTemplate.delete()
+
                 def saSelector1 = openshift.selector( "serviceaccount" )
                 saSelector1.describe()
 

--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -975,12 +975,12 @@ class OpenShiftDSL implements Serializable {
         }
 
         @NonCPS
-        private ArrayList<String> flattenLabels(Map labels) {
+        private ArrayList<String> flattenMap(Map pairs) {
             ArrayList<String> args = new ArrayList<>();
-            if (labels == null) {
+            if (pairs == null) {
                 return args;
             }
-            Iterator<Map.Entry> i = labels.entrySet().iterator();
+            Iterator<Map.Entry> i = pairs.entrySet().iterator();
             while (i.hasNext()) {
                 Map.Entry e = i.next();
                 // TODO: handle quotes, newlines, etc?
@@ -1019,26 +1019,34 @@ class OpenShiftDSL implements Serializable {
             return objectList != null && objectList.size() == 0;
         }
 
-        public Result label(Map newLabels, Object... ouserArgs) throws AbortException {
+        private Result runSubVerb(String action, Map pairs, Object... ouserArgs) throws AbortException {
             String[] userArgs = toStringArray(ouserArgs);
             List verbArgs = selectionArgs();
             if (kind != null && labels==null) {
                 verbArgs.add("--all");
             }
-            verbArgs.addAll(flattenLabels(newLabels));
-            Result r = new Result("label");
+            verbArgs.addAll(flattenMap(pairs));
+            Result r = new Result(action);
 
             if (_isEmptyStatic()) {
                 return r;
             }
 
             r.actions.add(
-                    (OcAction.OcActionResult)script._OcAction(buildCommonArgs("label", verbArgs, userArgs))
+                    (OcAction.OcActionResult)script._OcAction(buildCommonArgs(action, verbArgs, userArgs))
             );
-            r.failIf("Error during label");
+            r.failIf("Error during " + action);
             return r;
+
         }
 
+        public Result label(Map newLabels, Object... ouserArgs) throws AbortException {
+            return runSubVerb("label", newLabels, ouserArgs);
+        }
+
+        public Result annotate(Map newAnnotations, Object... ouserArgs) throws AbortException {
+            return runSubVerb("annotate", newAnnotations, ouserArgs);
+        }
 
         public Result describe(Object... ouserArgs) throws AbortException {
             String[] userArgs = toStringArray(ouserArgs);
@@ -1343,7 +1351,6 @@ class OpenShiftDSL implements Serializable {
                             (expandedKind+"s").equals(k)) {
                            newList.add(name);
                        }
-       
                     }
                 }
             }

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -962,6 +962,30 @@
             </ul>
         </dd>
         <dt>
+            <a name="Selector_annotate"/>
+            <code>Selector.annotate(annotations:Map, [args...:String]):Result</code><br />
+        </dt>
+        <dd>
+            <p>
+                <p style="margin-left: 1em; color:#657383;">
+                    Example:<br />
+                    <code>
+                        openshift.selector("pods").annotate([ k1:'v1', k2:'v2' ], "--overwrite")<br />
+                    </code>
+                </p>
+                <br />
+                Adds the specified annotations to the objects selected by the receiver.
+                <ul>
+                    <li>
+                        <b>annotations</b> - A map of annotations to apply (e.g. [ annotation1 : 'value1', annotation2 : 'value2' ])
+                    </li>
+                    <li>
+                        <b>args...</b> - An optional list of arguments which will be appended directly to the annotate invocation.
+                    </li>
+                </ul>
+            </p>
+        </dd>
+        <dt>
             <code id="Selector_startBuild">Selector.startBuild([args...:String]):StaticSelector</code><br />
         </dt>
         <dd>


### PR DESCRIPTION
Adds openshift.selector("foo").annotate([k1:"v1", k2:"v2"], "--overwrite")

Fixes #83