### PR TITLE
temporarily undo patch test

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -8,13 +8,13 @@ try {
         // Select the default cluster
         openshift.withCluster() {
             // Test openshift.patch and selector.patch
-            openshift.withProject() {
+            /*openshift.withProject() {
                 openshift.create("https://raw.githubusercontent.com/openshift/nodejs-ex/master/openshift/templates/nodejs.json")
                 openshift.newApp("nodejs-example")
                 openshift.patch("dc/nodejs-example", '\'{"spec":{"strategy":{"type":"Recreate"}}}\'')
                 def mySelector = openshift.selector("bc/nodejs-example")
                 mySelector.patch('\'{"spec":{"source":{"git":{"ref": "development"}}}}\'')
-            }
+            }*/
             // Select the default project
             openshift.withProject() {
 


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

ok we had a couple of multiple repo changes happen concurrently that were not compatible

1) my change in openshift/origin to run the client plugin test job twice (to exercise both the create and access object paths in the plugin test job) finally merged last night after a week and half of flakes

2) I merged @coreydaley 's test change for patch a few hours before that, forgetting about 1)

@coreydaley - I've commented out the change for now;  can you work on an update that checks for existence of the template, and either creates or accesses accordingly.  It should be exactly like what is done below for the mongodb template