### PR TITLE
Fix DSL lack of assignment for configured ClusterConfig

### DIFF
--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -304,7 +304,7 @@ class OpenShiftDSL implements Serializable {
             ClusterConfig cc = null;
 
             if (name != null) {
-                config.getClusterConfig(name);
+                cc = config.getClusterConfig(name);
             } else {
                 // See if a clusterName named "default" has been defined.
                 cc = config.getClusterConfig("default");


### PR DESCRIPTION
Existing ClusterConfig defined in Jenkins not being used because of a missed assignment in the OpenshiftDSL.groovy file

This pull request is here to fix that