### PR TITLE
add retry to RolloutManager

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -197,6 +197,9 @@ try {
                 sleep 3
                 dc2Selector.rollout().cancel()
 
+                // perform a retry on a failed or cancelled deployment
+                //dc2Selector.rollout().retry()
+
                 // validate some watch/selector error handling
                 try {
                     timeout(time: 10, unit: 'SECONDS') {

--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -1680,7 +1680,7 @@ class OpenShiftDSL implements Serializable {
         public Result resume(Object...args) throws AbortException { return runSubVerb("resume", args); }
         public Result status(Object...args) throws AbortException { return runSubVerb("status", args, true); }
         public Result undo(Object...args) throws AbortException { return runSubVerb("undo", args); }
-
+        public Result retry(Object...args) throws AbortException { return runSubVerb("retry", args); }
     }
 
 

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -1162,7 +1162,7 @@
             <code id="RolloutManager_latest">RolloutManager.latest([args...:String]):Result</code><br />
             <code id="RolloutManager_pause">RolloutManager.pause([args...:String]):Result</code><br />
             <code id="RolloutManager_resume">RolloutManager.resume([args...:String]):Result</code><br />
-            <code id="RolloutManager_status">RolloutManager.retry([args...:String]):Result</code><br />
+            <code id="RolloutManager_retry">RolloutManager.retry([args...:String]):Result</code><br />
             <code id="RolloutManager_status">RolloutManager.status([args...:String]):Result</code><br />
             <code id="RolloutManager_undo">RolloutManager.undo([args...:String]):Result</code><br />
         </dt>

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -1162,6 +1162,7 @@
             <code id="RolloutManager_latest">RolloutManager.latest([args...:String]):Result</code><br />
             <code id="RolloutManager_pause">RolloutManager.pause([args...:String]):Result</code><br />
             <code id="RolloutManager_resume">RolloutManager.resume([args...:String]):Result</code><br />
+            <code id="RolloutManager_status">RolloutManager.retry([args...:String]):Result</code><br />
             <code id="RolloutManager_status">RolloutManager.status([args...:String]):Result</code><br />
             <code id="RolloutManager_undo">RolloutManager.undo([args...:String]):Result</code><br />
         </dt>


### PR DESCRIPTION
`oc rollout retry` is missing from DSL. I'm sure there's more needed than just the Openshift DSL addition so I can update whatever else is necessary. While I know we can use `openshift.create('dc', 'mydeployment')`, since the CLI is pushing to use the `oc rollout` section, it should be there along with `undo`, `resume`, etc.