### PR TITLE
fix fetch of k8s connection env vars when running outside a pod

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
+++ b/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
@@ -115,6 +115,27 @@ public class ClusterConfig extends AbstractDescribableImpl<ClusterConfig>
         return "https://" + serviceHost + ":" + servicePort;
     }
 
+    /**
+     * Takes in defaults, with assumption that the 'env' pipeline global var
+     * is better populated as pipelines evolve
+     * 
+     * @return Returns a URL to contact the API server of the OpenShift cluster
+     *         running this node or throws an Exception if it cannot be
+     *         determined.
+     */
+    @Whitelisted
+    public static String getHostClusterApiServerUrl(String defaultHost, String defaultPort) {
+    	try {
+    		return getHostClusterApiServerUrl();
+    	} catch (IllegalStateException e) {
+    		if (defaultHost != null && defaultHost.length() > 0 &&
+    				defaultPort != null && defaultPort.length() > 0 ) {
+    			return "https://" + defaultHost + ":" + defaultPort;
+    		} else
+    			throw e;
+    	}
+    }
+
     // https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin
     // http://javadoc.jenkins-ci.org/credentials/com/cloudbees/plugins/credentials/common/AbstractIdCredentialsListBoxModel.html
     // https://github.com/jenkinsci/kubernetes-plugin/blob/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/KubernetesCloud.java

--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -203,7 +203,10 @@ class OpenShiftDSL implements Serializable {
             if (parent != null) {
                 return parent.getServerUrl();
             }
-            return ClusterConfig.getHostClusterApiServerUrl();
+            // fetching jenkins pipeline env from generic java without jenkins extensions
+            // proving more problematic ... leverage default patter in case System.getenv
+            // does not render desired result
+            return ClusterConfig.getHostClusterApiServerUrl(script.env.KUBERNETES_SERVICE_HOST, script.env.KUBERNETES_SERVICE_PORT_HTTPS);
         }
 
         public void setServerUrl(String serverUrl, boolean skipTLSVerify) {
@@ -318,7 +321,7 @@ class OpenShiftDSL implements Serializable {
             // Determine if name is a URL or a clusterName name. It is treated as a URL if it is *not* found
             // as a clusterName configuration name.
             ClusterConfig cc = null;
-
+            
             // in case of restart during the middle of a job run using this global var, reinit this transient
             // var
             if (config == null) {


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-client-plugin/issues/169