### PR TITLE
Support Configuration as Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,6 +865,16 @@ openshift.withCluster( 'mycluster' ) {
 }
 ```
 
+The cluster configuration can be exported and imported with the [Jenkins Configuration as Code Plugin](https://github.com/jenkinsci/configuration-as-code-plugin).
+
+```yaml
+unclassified:
+  openshift:
+    clusterConfigs:
+    - name: "mycluster"
+      serverUrl: "example.com"
+```
+
 ## Setting up Credentials
 To define a new credential for the DSL in the Jenkins credential store, navigate to
 Credentials -> System -> Global credentials -> Add Credentials (you can the domain based

--- a/src/main/java/com/openshift/jenkins/plugins/OpenShift.java
+++ b/src/main/java/com/openshift/jenkins/plugins/OpenShift.java
@@ -90,6 +90,10 @@ public class OpenShift extends AbstractDescribableImpl<OpenShift> {
             return Collections.unmodifiableList(clusterConfigs);
         }
 
+        public void setClusterConfigs(List<ClusterConfig> configs) {
+            clusterConfigs = configs;
+        }
+
         /**
          * Determines if a cluster has been configured with a given name. If a
          * cluster has been configured with the name, its definition is


### PR DESCRIPTION
[Jenkins Configuration as Code](https://github.com/jenkinsci/configuration-as-code-plugin) is great plugin which enables to export and import the configuration as a yaml file.
This PR adds a setter to the OpenShift class, which enable the configuration as code plugin to work.
Otherwise it is not possible to import or export the settings.