### PR TITLE
get back to essential pre 1.0.17 file processing for watch/action

### DIFF
--- a/examples/multicontainer-pipieline.groovy
+++ b/examples/multicontainer-pipieline.groovy
@@ -1,0 +1,41 @@
+pipeline {
+    agent {
+      kubernetes {
+        cloud 'openshift'
+        label 'mypod'
+        defaultContainer 'jnlp'
+        yaml """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: some-label-value
+spec:
+  serviceAccount: jenkins
+  containers:
+  - name: maven
+    image: docker.io/openshift/jenkins-agent-maven-35-centos7:v4.0
+    command:
+    - cat
+    tty: true
+"""
+      }
+    }
+      stages {
+          stage('build') {
+              steps {
+                  container('maven') {
+                      script {
+                          openshift.withCluster() {
+                              openshift.withProject() {
+                                  def dcSelector = openshift.selector("dc", "jenkins")
+                                  dcSelector.describe()
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  }
+  


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-client-plugin/issues/209

@openshift/sig-developer-experience fyi ... as I mentioned in scrum today, in addition to some upstream users seeing these intermittent issues, I believe I've seen an instance or two of this (blocking on the `Files.readAllBytes` call) in some recent `aws-builds` runs on CI

These change more closely approximate what we use to do in this space prior to our abandoning the durable task / bourne shell stuff that proved untenable for a set of template param / env var based `oc` scenarios