### PR TITLE
Porting the current process launching approach to ClientCommandRunner

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandRunner.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandRunner.java
@@ -2,18 +2,17 @@ package com.openshift.jenkins.plugins.util;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Launcher;
 import hudson.Proc;
-import hudson.Util;
 import hudson.remoting.FastPipedInputStream;
 import hudson.remoting.FastPipedOutputStream;
-import hudson.remoting.RemoteOutputStream;
-import hudson.remoting.VirtualChannel;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
-import org.jenkinsci.remoting.RoleChecker;
 
+import javax.annotation.Nonnull;
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.logging.Level;
@@ -22,7 +21,8 @@ import java.util.logging.Logger;
 /***
  * {@link ClientCommandRunner} runs `oc` on a slave
  */
-public class ClientCommandRunner {
+public class ClientCommandRunner implements Serializable {
+    private static final long serialVersionUID = 42L;
     private static final Logger LOGGER = Logger.getLogger(ClientCommandRunner.class.getName());
     // creating a thread pool for output consumers
     private static Executor pool;
@@ -39,13 +39,15 @@ public class ClientCommandRunner {
     }
 
     /***
-     * a {@link OutputObserver} will be notified when {@link ClientCommandRunner} reads a newline from stdout or stderr of the running oc process
+     * a {@link OutputObserver} will be notified when {@link ClientCommandRunner} reads a new line from stdout or stderr of the running oc process
      */
     public interface OutputObserver {
         /***
          * This method will be called every time the ClientCommandRunner reads a line from the stdout/stderr from the remote `oc` process.
          * @param line a line of output
          * @return true to indicate the ClientCommandRunner to interrupt the `oc` process immediately.
+         * @throws IOException when I/O error
+         * @throws InterruptedException when the reading threads are interrupted
          */
         boolean onReadLine(String line) throws IOException, InterruptedException;
     }
@@ -60,10 +62,12 @@ public class ClientCommandRunner {
      * Create a new {@link ClientCommandRunner} instance.
      * @param command command to run OpenShift client tool
      * @param filePath current directory
+     * @param envVars environment variables
      * @param stdoutOutputObserver a {@link OutputObserver} that will be notified whenever {@link ClientCommandRunner} reads a line from stdout of `oc` process
      * @param stderrOutputObserver a {@link OutputObserver} that will be notified whenever {@link ClientCommandRunner} reads a line from stderr of `oc` process
      */
-    public ClientCommandRunner(String[] command, FilePath filePath, EnvVars envVars, OutputObserver stdoutOutputObserver, OutputObserver stderrOutputObserver) {
+    public ClientCommandRunner(@Nonnull String[] command, @Nonnull FilePath filePath, @Nonnull EnvVars envVars,
+                               @Nonnull OutputObserver stdoutOutputObserver, @Nonnull OutputObserver stderrOutputObserver) {
         this.command = command;
         this.filePath = filePath;
         this.envVars = envVars;
@@ -71,7 +75,7 @@ public class ClientCommandRunner {
         this.stderrOutputObserver = stderrOutputObserver;
     }
 
-    private static class OcOutputConsumer implements Callable<Boolean> {
+    private static class OcOutputConsumer implements Callable<Object> {
         private InputStream in;
         private OutputObserver outputObserver;
 
@@ -95,109 +99,62 @@ public class ClientCommandRunner {
         }
     }
 
-    private static class OcCallable implements FilePath.FileCallable<Integer> {
-        private String[] command;
-        private EnvVars envVars;
-        private OutputStream out;
-        private OutputStream err;
-
-        public OcCallable(String[] command, EnvVars envVars, RemoteOutputStream out, RemoteOutputStream err) {
-            this.command = command;
-            this.envVars = envVars;
-            this.out = out;
-            this.err = err;
-        }
-
-        @Override
-        public void checkRoles(RoleChecker checker) throws SecurityException {
-        }
-
-        @Override
-        public Integer invoke(File currentDir, VirtualChannel channel) throws IOException, InterruptedException {
-            Proc.LocalProc proc = null;
-            try (OutputStream out = this.out; OutputStream err = this.err) {
-                // per explanations like https://stackoverflow.com/questions/10035383/setting-the-environment-for-processbuilder
-                // even with propagating updates to the PATH env down to the creations of Proc.LocalProc and ProcessBuilder, 
-                // they don't even effect the environment in which the ProcessBuilder is running. So to find the `oc` when the 
-                // PATH is updated via the 'tool' step, we need to either 
-                // 1) prepend the right dir from the path for 'oc'
-                // 2) invoke a shell that then launches the actual 'oc' command, where we update the PATH prior
-                // Our use of the jenkins durable task and bourne/windows scripts did 2), but because of 
-                // https://bugzilla.redhat.com/show_bug.cgi?id=1625518 we analyze the PATH env var and do 1)
-                String path = envVars.get("PATH");
-                // default if running the openshift jenkins images
-                String dirToUse = "/bin/";
-                if (path == null || path.length() == 0) {
-                    LOGGER.warning("PATH not properly set prior to invocation of 'oc'");
-                } else {
-                    String[] dirs = path.split(File.pathSeparator);
-                    for (String dir : dirs) {
-                        if (new File(dir, "oc").canExecute() || new File(dir, "oc.exe").canExecute()) {
-                            dirToUse = dir.trim();
-                            break;
-                        }
-                    }
-                }
-                // sanity check, make sure oc is our first command, though it always should be
-                if (command[0].trim().equals("oc") || command[0].trim().equals("oc.exe")) {
-                    command[0] = dirToUse + File.separator + command[0].trim();
-                }
-                
-                proc = new Proc.LocalProc(command, Util.mapToEnv(envVars), null, out, err, currentDir);
-                return proc.join();
-            } finally {
-                if (proc != null && proc.isAlive())
-                    proc.kill();
-            }
-        }
-    }
-
     /***
      * Run `oc` on a slave and wait for it to be exit
+     * @param launcher Launcher for launching a remote process
      * @return the exit status code of `oc`
      * @throws IOException when error reading stdin/stdout or calling the observers
      * @throws InterruptedException when the reading threads are interrupted
+     * @throws ExecutionException error when executing closures of observers
      */
-    public int run() throws IOException, InterruptedException, ExecutionException {
-        List<Future<Boolean>> ocOutputConsumerFutures = new ArrayList<>(2);
-        Future<Integer> remoteOCProcessFuture = null;
+    public int run(@Nonnull Launcher launcher) throws IOException, InterruptedException, ExecutionException {
+        CompletionService<Object> completionService = new ExecutorCompletionService<>(pool);
+        Proc proc = null;
+        int exitStatus = -1;
+        List<Future<Object>> futures = new ArrayList<>(3);
         try (FastPipedOutputStream stdout = new FastPipedOutputStream();
-             InputStream redirectedStdout = new FastPipedInputStream(stdout);
+             FastPipedInputStream redirectedStdout = new FastPipedInputStream(stdout);
              FastPipedOutputStream stderr = new FastPipedOutputStream();
-             InputStream redirectedStderr = new FastPipedInputStream(stderr)) {
+             FastPipedInputStream redirectedStderr = new FastPipedInputStream(stderr)) {
             // running `oc` remotely
-            // NOTE: Launcher is not used to start a remote process because of Jenkins bugs described on https://issues.jenkins-ci.org/browse/JENKINS-53586
-            //   and https://issues.jenkins-ci.org/browse/JENKINS-53422.
-            remoteOCProcessFuture = filePath.actAsync(new OcCallable(command, envVars, new RemoteOutputStream(stdout), new RemoteOutputStream(stderr)));
-
-            // reading the output (stdout and stderr) from the remote `oc` process
-            CompletionService<Boolean> completionService = new ExecutorCompletionService<>(pool);
+            Launcher.ProcStarter ps = launcher.launch().cmds(Arrays.asList(command)).envs(envVars).pwd(filePath).quiet(true).stdout(stdout).stderr(stderr);
 
             // handling stderr
-            ocOutputConsumerFutures.add(completionService.submit(new OcOutputConsumer(redirectedStderr, stderrOutputObserver)));
+            futures.add(completionService.submit(new OcOutputConsumer(redirectedStderr, stderrOutputObserver)));
 
             // handling stdout
-            ocOutputConsumerFutures.add(completionService.submit(new OcOutputConsumer(redirectedStdout, stdoutOutputObserver)));
+            futures.add(completionService.submit(new OcOutputConsumer(redirectedStdout, stdoutOutputObserver)));
 
-            // waiting for output handlers to stop
-            for (int i = 0; i < ocOutputConsumerFutures.size(); ++i) {
-                boolean shouldInterrupt = completionService.take().get();
-                if (shouldInterrupt) { // an observer requests interrupting the remote `oc` process
-                    remoteOCProcessFuture.cancel(true);
+            // start remote `oc` process
+            proc = ps.start();
+            final Proc proc1 = proc; // make it "final"
+            // future to wait for remote `oc` process to stop
+            Future<Object> procFuture = completionService.submit(() -> proc1.join());
+            futures.add(procFuture);
+
+            // waiting for any of oc process, stdout consumer, and stderr consumer to stop
+            for (int i = 0; i < futures.size(); ++i) {
+                Future<Object> completedFuture = completionService.take();
+                if (completedFuture == procFuture) {
+                    // the remote `oc` process has exited
+                    exitStatus = (int) completedFuture.get();
+                    // closing stdout/stderr so that observers will stop
+                    stdout.close();
+                    stderr.close();
+                    redirectedStdout.close();
+                    redirectedStderr.close();
+                } else if ((Boolean) completedFuture.get()) {
+                    // an observer requests interrupting the remote `oc` process
+                    proc.kill();
                 }
             }
-            // waiting for `oc` to stop and return the exit status.
-            if (remoteOCProcessFuture.isCancelled())
-                return -1; // indicates the process is interrupted by an OutputObserver
-            else
-                return remoteOCProcessFuture.get();
+            return exitStatus;
         } finally {
-            // ensuring the `oc` process is terminated
-            if (remoteOCProcessFuture != null && !remoteOCProcessFuture.isDone()) {
-                remoteOCProcessFuture.cancel(true);
-            }
-            // ensuring all output handlers are stopped
-            for (Future<Boolean> future : ocOutputConsumerFutures) {
+            // ensuring the remote `oc` process is terminated
+            if (proc != null)
+                proc.kill();
+            // ensuring all futures are stopped
+            for (Future<Object> future : futures) {
                 if (!future.isDone())
                     future.cancel(true);
             }


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-client-plugin/issues/222

This PR ports the current process launching approach to ClientCommandRunner
and use ClientCommandRunner fin OcAction and OcWatch steps.

ClientCommandRunner uses piped streams (FastPipedOutputStream and FastPipedInputputStream) to transfer output (stdout/stderr) of the remote process
to Jenkins master, and leverages Apache Common IO's IOUtils.lineIterator to read the output line by line without reading fully to memory or disk files.

Like the current implementation of OcWatch, this PR's implementation also relaunches the `oc --watch` command when it returns 0.

----

Hi, I come again to promote the `ClientCommandRunner` :)

### Background of this change

We are running tens of OpenShift Pipeline jobs internally at Red Hat (https://paas.upshift.redhat.com/console/project/waiverdb-test/browse/pipelines). Several weeks ago, after we upgraded our Jenkins master with OpenShift client plugin, we found the OcWatch step frequently timed-out. Then we tried to increase the time limit but things didn't become better.

Then I took a close look to the OcWatch step, finding out that there is possibility that the OcWatch step hangs even if the watched build is complete (See https://github.com/openshift/jenkins-client-plugin/issues/222#issuecomment-470372725). v1.0.27 doesn't help with this.

I went through the source code of OcWatch, then realized that lots of changes happened since I contributed #176. Honestly, I didn't get the root cause of the hanging issue. Probably it is caused by bugs of Jenkins (or other plugin)'s API, probably not.

### So I ported the new way of launching oc process to ClientCommandRunner

As we discussed in https://github.com/openshift/jenkins-client-plugin/pull/176#issuecomment-420923583, the API `ProcStarter.readStderr()` doesn't work properly so that I switched `ProcStarter` to `Proc.LocalProc` to work around the annoying Jenkins bug.

However,  as @gabemontero pointed out, `Proc.LocalProc` doesn't cooperate with Kubernetes Plugin's sidecar containers (https://github.com/openshift/jenkins-client-plugin/pull/176#issuecomment-446631550).

Today, I ported the the current way of process launching to `ClientCommandRunner`, and reintroduced `ClientCommandRunner` to OcAction and OcWatch steps. I tested it in our pipeline jobs and it seemed to work fine.  Finally, I created this PR and hope to revive `ClientCommandRunner`.

One missing part I know is the workaround for JSON parsing exception in OcWatch is not ported. Could anyone explain why it is needed?

If this is the way to go, please help review and check if anything missing in the PR. I know it is risky to switch the implementation, but I really think it is a better way to running remote `oc` process. 