### PR TITLE
Fix issues of FindOc

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
@@ -64,9 +64,8 @@ public class ClientCommandBuilder implements Serializable {
         // https://bugzilla.redhat.com/show_bug.cgi?id=1625518 we analyze the PATH env var and do 1)
         OsType targetType = filePath.act(new getOsType());
         String path = envVars.get("PATH");
-        ArrayList<String> foundOcs = new ArrayList<String>();
-        FindOC finder = new FindOC();
-        finder.setPath(path);
+        List<String> foundOcs = new ArrayList<String>();
+        FindOC finder = new FindOC(path);
         try {
             foundOcs = filePath.act(finder);
         } catch (Throwable t) {

--- a/src/main/java/com/openshift/jenkins/plugins/util/FindOC.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/FindOC.java
@@ -8,72 +8,30 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import hudson.Platform;
 import jenkins.security.MasterToSlaveCallable;
 
-public class FindOC extends MasterToSlaveCallable<ArrayList<String>, Throwable> {
+public class FindOC extends MasterToSlaveCallable<List<String>, Throwable> {
 
     private static final long serialVersionUID = 1L;
     private String path;
-    public String getPath() {
-        return path;
-    }
-    public void setPath(String path) {
+
+    public FindOC(String path) {
         this.path = path;
     }
-    public FindOC() {
-        
-    }
+
     @Override
-    public ArrayList<String> call() throws Throwable {
-        String ocFileName = "oc";
-        String pathSepChar = ":";
-        if (Platform.current() == Platform.WINDOWS) {
-            ocFileName = "oc.exe";
-            pathSepChar = ";";
-        }
-        ArrayList<Path> paths = new ArrayList<Path>();
-        String[] dirs = path.split(pathSepChar);
-        for (String dir : dirs) {
-            paths.add(Paths.get(dir));
-        }
-        
-        final String oc = ocFileName;
-        final ArrayList<String> ocPath = new ArrayList<String>();
-        for (Path path : paths) {
-            Files.walkFileTree(path, new java.nio.file.FileVisitor<Path>() {
-
-                @Override
-                public FileVisitResult postVisitDirectory(Path arg0, IOException arg1) throws IOException {
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult preVisitDirectory(Path arg0, BasicFileAttributes arg1) throws IOException {
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult visitFile(Path path, BasicFileAttributes attr) throws IOException {
-                    if (!attr.isRegularFile())
-                        return FileVisitResult.CONTINUE;
-                    File f = path.toFile();
-                    if (!f.canRead() && !f.canExecute())
-                        return FileVisitResult.CONTINUE;
-                    if (path.getFileName().toString().equals(oc))
-                        ocPath.add(path.toString());
-                    return FileVisitResult.CONTINUE;
-                }
-
-                @Override
-                public FileVisitResult visitFileFailed(Path arg0, IOException arg1) throws IOException {
-                    return FileVisitResult.CONTINUE;
-                }
-                
-            });            
-        }
-        return ocPath;
+    public List<String> call() {
+        final String ocFileName = Platform.current() == Platform.WINDOWS ? "oc.exe" : "oc";
+        String[] dirs = path.split(File.pathSeparator);
+        return Arrays.stream(dirs)
+                .map(dir -> new File(dir, ocFileName))
+                .filter(file -> file.isFile() && file.canExecute())
+                .map(file -> file.getAbsolutePath())
+                .collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
`FindOc` uses `Path.walkFileTree()` to visit all directories (and their subdirectories) in `PATH`. However, there are 2 problems:

1. My development computer is Mac, where `oc` is installed with HomeBrew. The `oc` is located at `/usr/local/bin/oc`, which is a symlink to `../Cellar/openshift-cli/3.11.0/bin/oc`. However, by default `Path.walkFileTree()` doesn't follow symlinks (https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#walkFileTree-java.nio.file.Path-java.util.Set-int-java.nio.file.FileVisitor-). When it visits `/usr/local/bin/oc`, `attr.isRegularFile()` returns `false`, so `oc` is not discovered. Using normal `File.canExecute()` API just works fine because it follows symlink.

2. Visiting subdirectories doesn't seem to be needed. Rather than work through the file tree, this PR just concatenates the each directory in `PATH` and `ocFileName` then checks if resulting location is an executable file.