### PR TITLE
Updated verifyService to support headless services with selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ openshift.withCluster() {
 ```
 
 If you are looking for the equivalent of `openshiftVerifyService` from [the OpenShift Jenkins Plugin](https://github.com/openshift/jenkins-plugin), we added a similar operation.
-
+This works with Services with ClusterIP as well as [headless Services (with selectors)](https://kubernetes.io/docs/concepts/services-networking/service/#with-selectors) in the namespace specified by the openshift.withProject().
 ```groovy
 openshift.withCluster() {
     openshift.withProject() {

--- a/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
+++ b/src/main/resources/com/openshift/jenkins/plugins/pipeline/OpenShiftGlobalVariable/help.jelly
@@ -206,13 +206,17 @@
             <code id="openshift_verifyService">openshift.verifyService(svc_name:String):boolean</code>
         </dt>
         <dd>
+            <p>
+                Allows you to check if your Openshift service is reachable or not. This works with headless Services (with Selectors)
+                as well as normal Services with ClusterIP which are in the namespace specified by the openshift.withProject().
+            </p>
             <p  style="margin-left: 1em; color:#657383;">
                 <code>
                     def connected = openshift.verifyService(${svcName});<br/>
-                    if (connected)<br/>
-                        echo "Able to connect to service $${svcName}"<br/>
+                        if (connected)<br/>
+                             echo "Able to connect to service $${svcName}"<br/>
                 </code>
-              </p>
+            </p>
             <p>
                 Returns true or false based on the ability to connect to the IP and port associated with the service specified.
             </p>


### PR DESCRIPTION
Closed PR https://github.com/openshift/jenkins-client-plugin/pull/258 by mistake.
Fixes https://github.com/openshift/jenkins-client-plugin/issues/217

##### Update:
I used the `dig` command as follows from a pod in one namespace to query a headless service in another which worked. 
```sh
dig nodejs-ex-headless.jenkins-headless-test.svc.cluster.local A +short                                                                           
10.130.1.173
10.131.0.74
10.131.0.75
```
We get the IPs of the pods above. 

If I use `openshift.verifyService` to test the same service, we get the following error below
```
ERROR: Unable to retrieve object markup with get; action failed: {reference={}, err=Error from server (NotFound): services "nodejs-ex-headless.jenkins-headless-test.svc.cluster.local" not found
, verb=get, cmd=oc --server=https://172.30.0.1:443 --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt --namespace=vibhav-jenkins --token=XXXXX get service/nodejs-ex-headless.jenkins-headless-test.svc.cluster.local -o=json , out=, status=1}
```

cc @gabemontero @sthaha