### PR TITLE
Upgrade findbugs for java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
         -->
-        <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
         <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 


### PR DESCRIPTION
Findbugs 3.0.1 is failing during mvn release:prepare on OSX and Java 8
Fixed with Findbugs 3.0.5