### PR TITLE
Fix 306 namespace not passed to raw command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Deploys locally the plugin in a pod which has label name=jenkins
+# You must be correctly logged in an OpenShift or Kubernetes cluster (KUBECONFIG set or oc login)
+pod_name=$( oc get pods -l name=jenkins --output=name | cut -f2 -d/)
+plugin_path=/var/lib/jenkins/plugins
+plugin_name=openshift-client
+plugin_dst_extension=jpi
+plugin_src_extension=hpi
+plugin_full_path=$plugin_path/$plugin_name.$plugin_dst_extension
+
+local_plugin_path=target/$plugin_name.$plugin_src_extension
+remote_plugin_path=$pod_name:$plugin_full_path
+remote_plugin_directory=$plugin_path/$plugin_name
+
+echo "Copying $local_plugin_path into $remote_plugin_path"
+oc cp $local_plugin_path  $remote_plugin_path
+echo "Unzipping $plugin_full_path into $remote_plugin_directory" 
+oc exec $pod_name -- unzip -o $plugin_full_path -d $remote_plugin_directory
+echo "Restarting container"
+oc exec $pod_name -- kill 1

--- a/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
+++ b/src/main/resources/com/openshift/jenkins/plugins/OpenShiftDSL.groovy
@@ -888,12 +888,29 @@ class OpenShiftDSL implements Serializable {
         }
         return l;
     }
+	
+        /**
+	 * See details in toSingleString for rationale.
+	 */
+	@NonCPS
+	private static List<String> toStringList(Object[] objects) {
+		List<String> l = new ArrayList<String>();
+		if (objects != null) {
+			for (int i = 0; i < objects.length; i++) {
+				l.add(objects[i].toString());
+			}
+		}
+		return l;
+	}
 
+	
+	
 
     public Result raw(Object... oargs) {
         String[] args = toStringArray(oargs);
+		List<String> argsList = toStringList(oargs);
         Result r = new Result("raw");
-        r.actions.add((OcAction.OcActionResult)script._OcAction(buildCommonArgs("", null, args)));
+        r.actions.add((OcAction.OcActionResult)script._OcAction(buildCommonArgs("", argsList, null)));
         r.failIf("raw command " + args + " returned an error");
         return r;
     }


### PR DESCRIPTION
Fixes #306 

Allows to pass verb arguments to openshift.raw() command, especially the "-n namespace" or "--namespace=value" to be able to override the default namespace.

Adds also a few formatting.
