### PR TITLE
Bug 1837362: Sensitive data exposed on pipeline failure

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/pipeline/OcAction.java
+++ b/src/main/java/com/openshift/jenkins/plugins/pipeline/OcAction.java
@@ -1,6 +1,7 @@
 package com.openshift.jenkins.plugins.pipeline;
 
 import com.openshift.jenkins.plugins.util.ClientCommandBuilder;
+import com.openshift.jenkins.plugins.util.ClientCommandOutputCleaner;
 import com.openshift.jenkins.plugins.util.ClientCommandRunner;
 import hudson.*;
 import hudson.model.Computer;
@@ -63,14 +64,18 @@ public class OcAction extends AbstractStepImpl {
         public int status;
         @Whitelisted
         public HashMap<String, String> reference = new HashMap<String, String>();
+        @Whitelisted
+        public boolean verbose = false;
 
         public HashMap toMap() {
             HashMap m = new HashMap();
             m.put("verb", verb);
             m.put("cmd", cmd);
             m.put("out", out);
-            m.put("err", err);
-            m.put("reference", reference);
+            m.put("err", ClientCommandOutputCleaner.redactSensitiveData(err));
+            if (verbose) {
+                m.put("reference", reference);
+            }
             m.put("status", status);
             return m;
         }
@@ -206,6 +211,7 @@ public class OcAction extends AbstractStepImpl {
             result.reference = step.reference;
             result.out = stdout.toString();
             result.err = stderr.toString();
+            result.verbose = step.verbose;
 
             if (step.verbose) {
                 listener.getLogger().println("Verbose sub-step output:");

--- a/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandOutputCleaner.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandOutputCleaner.java
@@ -1,0 +1,7 @@
+package com.openshift.jenkins.plugins.util;
+
+public class ClientCommandOutputCleaner {
+    public static String redactSensitiveData(final String output){
+        return output.replaceAll("(\"data\":)\\{(.*?)\\}", "$1{ REDACTED }");
+    }
+}


### PR DESCRIPTION
Resolves the ticket #326 

i.e. the following output:
```
{err=Error from server (BadRequest): error when creating "/Users/rmaloku/work/jenkins-client-plugin/work/workspace/test-ocp/apply2288494789001734078.markup": Secret in version "v1" cannot be handled as a Secret: v1.Secret.Data: decode base64: illegal base64 data at input byte 4, error found in #10 byte of ...|t":"xxxxK","secretKe|..., bigger context ...|{"apiVersion":"v1","data":{"secret":"xxxxK","secretKey":"YWRtaW4K"},"kind":"Secret","metadata|...
``` 
is printed as:
```
{err=Error from server (BadRequest): Secret in version "v1" cannot be handled as a Secret: v1.Secret.Data: decode base64: illegal base64 data at input byte 4, error found in #10 byte of ...|t":"xxxxK","secretKe|..., bigger context ...|{"apiVersion":"v1","data":{ REDACTED },"kind":"Secret","metadata|...
```

The important section is: **"data":{ REDACTED }**

FYI: I didn't hide the following section `|t":"xxxxK","secretKe|` as it provides the user with information of where the mistake is. Though I am open for your suggestions if we want to hide this as well.