### PR TITLE
Bug 1841315: get test pipeline working after unskipping openshift build tests

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -292,9 +292,7 @@ void actualTest() {*/
                     if (dc2Selector.exists()) {
                         openshift.delete("dc", "jenkins-second-deployment")
                     }
-                    openshift.run("jenkins-second-deployment", "--image=docker.io/openshift/jenkins-2-centos7:latest")
-                    dc2Selector.rollout().status("-w")
-    
+
                     // Empty static / selectors are powerful tools to check the state of the system.
                     // Intentionally create one using a narrow and exercise it.
                     emptySelector = openshift.selector("pods").narrow("bc")
@@ -305,12 +303,13 @@ void actualTest() {*/
                     emptySelector.label(["x":"y"]) // Should have no impact
     
                     // sanity check for latest and cancel
-                    dc2Selector.rollout().latest()
+                    def dc3Selector = openshift.selector("dc", "mongodb")
+                    dc3Selector.rollout().latest()
                     sleep 3
-                    dc2Selector.rollout().cancel()
+                    dc3Selector.rollout().cancel()
     
                     // perform a retry on a failed or cancelled deployment
-                    //dc2Selector.rollout().retry()
+                    //dc3Selector.rollout().retry()
     
                     // validate some watch/selector error handling
                     try {


### PR DESCRIPTION
So we had to disable https://github.com/openshift/origin/blob/master/test/extended/builds/pipeline_origin_bld.go when https://bugzilla.redhat.com/show_bug.cgi?id=1783530 first arose

That was done via https://github.com/openshift/origin/pull/24304

I noticed that https://bugzilla.redhat.com/show_bug.cgi?id=1783530 was finally marked verified earlier this month as the JDK fix we depended on eventually landed

In creating https://github.com/openshift/origin/pull/25033 the client plugin test using this file was failling.

I reproduced locally, and verified these changes locally.

Once this merges, I'll update the re-enabled test (clean up some of the cleanup stuff) and finish re-enabling the test.

These changes @akram @waveywaves are of course not an exact change from the `jenkins-second-deployment` usage, which I'm assuming you all started to move off of becasue of memory demands, but is close enough for now IMO, and sufficient to get the test re-enablement going.

Finally, as a reminder, the pipeline_jenkins_e2e.go tests stayed unskipped during all this.

