### PR TITLE
Comment check for dc in examples

### DIFF
--- a/examples/jenkins-image-sample.groovy
+++ b/examples/jenkins-image-sample.groovy
@@ -288,10 +288,14 @@ void actualTest() {*/
     
                     // add this rollout -w test when v0.9.6 is available in our centos image so
                     // the overnight tests pass
-                    def dc2Selector = openshift.selector("dc", "jenkins-second-deployment")
-                    if (dc2Selector.exists()) {
-                        openshift.delete("dc", "jenkins-second-deployment")
-                    }
+			
+		    // Commenting these out as failure on e2e tests seem to be happening here
+		    // The following deploymentConfig is not supposed to exist as jenkins-second-deployment is not created above
+	            // dc2Selector.exists() returns true which is incorrect. And the command following it fails with the same reason.
+                    // def dc2Selector = openshift.selector("dc", "jenkins-second-deployment")
+                    // if (dc2Selector.exists()) {
+                    //     openshift.delete("dc", "jenkins-second-deployment")
+                    // }
 
                     // Empty static / selectors are powerful tools to check the state of the system.
                     // Intentionally create one using a narrow and exercise it.


### PR DESCRIPTION
Tests fail on e2e-aws-jenkins with the client trying to delete the non existent DeploymentConfig.

https://github.com/openshift/jenkins-client-plugin/commit/4f11936fc995ced1b080d8f5261b0482d26ac5e2 removed the creation of jenkins-second-deployment and removing this is the next step to ensuring that we are only testing dry-run for this DeployementConfig. 

Running this test on a Jenkins Instance without this change passes, but this PR ensures that we don't come across this error in e2e tests.

Related PR https://github.com/openshift/origin/pull/25096