### PR TITLE
add various commented out tests back; duplicate remaining openshift/origin test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ all: test-e2e
 
 
 test-e2e:
-	KUBERNETES_CONFIG=${KUBECONFIG} go test -parallel 1 -timeout 30m -v ./test/e2e/...
+	KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 30m -v ./test/e2e/...
 
 


### PR DESCRIPTION
OK, so with this PR, I added back a bunch of tests that had been commented out of our uber regression pipeline.

In doing so, I broke them out into separate pipelines and tests.

Among other things, I'm curious how many Jenkins instances we can launch in parallel, as that had been an historical issue, especially in the 3.x days.  Let's see how this does when we are "only doing jenkins".

I also duplicated that last remaining client plugin test in openshift/origin, https://github.com/openshift/origin/blob/master/test/extended/builds/pipeline_origin_bld.go#L225-L264

In theory, one this merges, we can start creating client plugin periodics if we like, remove all client plugin tests from openshift/origin, and still have some sense of confidence that we'll catch, assuming our periodics run frequently enough, of quickly catching any regressions core OCP could have introduced.

@openshift/openshift-team-build-api @openshift/team-devtools-jenkins FYI