### PR TITLE
Fix oc command line when paths contains spaces

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
+++ b/src/main/java/com/openshift/jenkins/plugins/util/ClientCommandBuilder.java
@@ -290,7 +290,7 @@ public class ClientCommandBuilder implements Serializable {
 			cmd.add("--insecure-skip-tls-verify");
 		} else {
 			if (this.caPath != null) {
-				cmd.add("--certificate-authority=" + this.caPath);
+				cmd.add("--certificate-authority=\"" + this.caPath + "\"");
 			}
 		}
 


### PR DESCRIPTION
Some variables that point to file can have space, for example in the name of the Jenkins job. In this case the command line produce a error in the process execution. Surrounding the path with quote solve the issue.