### PR TITLE
add nullpointer to exceptions to catch if openshift-sync isn't installed

### DIFF
--- a/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
+++ b/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
@@ -163,9 +163,11 @@ public class ClusterConfig extends AbstractDescribableImpl<ClusterConfig> implem
         // relevent class loader. If the plugin is not installed, it is just ignored
         try {
             PluginWrapper plugin = Jenkins.get().pluginManager.getPlugin(OPENSHIFT_SYNC_PLUGIN_NAME);
-            Class clazz = plugin.classLoader.loadClass(IO_OPENSHIFT_CREDENTIALS_CLASS_NAME);
-            standardListBoxModel.includeAs(ACL.SYSTEM, Jenkins.get(), clazz);
-        } catch (ClassNotFoundException | NullPointerException e) {
+            if (plugin != null) {
+                Class clazz = plugin.classLoader.loadClass(IO_OPENSHIFT_CREDENTIALS_CLASS_NAME);
+                standardListBoxModel.includeAs(ACL.SYSTEM, Jenkins.get(), clazz);
+            }
+        } catch (ClassNotFoundException e) {
             LOGGER.warning("Class not found: " + IO_OPENSHIFT_CREDENTIALS_CLASS_NAME);
         }
         standardListBoxModel.includeCurrentValue(credentialsId);

--- a/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
+++ b/src/main/java/com/openshift/jenkins/plugins/ClusterConfig.java
@@ -165,7 +165,7 @@ public class ClusterConfig extends AbstractDescribableImpl<ClusterConfig> implem
             PluginWrapper plugin = Jenkins.get().pluginManager.getPlugin(OPENSHIFT_SYNC_PLUGIN_NAME);
             Class clazz = plugin.classLoader.loadClass(IO_OPENSHIFT_CREDENTIALS_CLASS_NAME);
             standardListBoxModel.includeAs(ACL.SYSTEM, Jenkins.get(), clazz);
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | NullPointerException e) {
             LOGGER.warning("Class not found: " + IO_OPENSHIFT_CREDENTIALS_CLASS_NAME);
         }
         standardListBoxModel.includeCurrentValue(credentialsId);


### PR DESCRIPTION
If the openshift-sync plugin can't be loaded it throws a nullpointer therefore it should also catch nullpointers. 

fixes #383 