### PR TITLE
JNKS-267: check JENKINS-IMAGE existence, tag into jenkins imagestream, from Makefile test-e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all: test-e2e
 
 
 test-e2e:
+	./hack/tag-ci-image.sh
 	KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 30m -v ./test/e2e/...
 
 

--- a/hack/tag-ci-image.sh
+++ b/hack/tag-ci-image.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+echo "Jenkins image from CI pipeline:jenkins: ${JENKINS_IMAGE}"
+if [[ -z ${JENKINS_IMAGE} ]]; then
+    echo "No jenkins image env var found, not overriding jenkins imagestream for e2e test of jenkins-client-plugin."
+else
+    echo "Tagging the CI generated Jenkins image ${JENKINS_IMAGE} from pipeline:jenkins into the test cluster's jenkins imagestream in the openshift namespace"
+    echo "Current contents of the jenkins imagestream in the openshift namespace"
+    oc describe is jenkins -n openshift
+    echo "Tagging ${JENKINS_IMAGE} into the jenkins imagestream in the openshift namespace"
+    oc tag --source=docker ${JENKINS_IMAGE} openshift/jenkins:2
+    # give some time for the image import to finish; watching from the CLI is non-trivial
+    sleep 30
+    echo "New contents of the jenkins imagestream in the openshift namespace"
+    oc describe is jenkins -n openshift
+fi


### PR DESCRIPTION
since the client plugin  itself does not need to use the CI step registry, a copy the work from https://github.com/openshift/release/pull/27009 

after this merges, I'll update the step-registry and see if we can use the new script defined here