### PR TITLE
OCPBUGS-7636,OCPBUGS-6023,OCPBUGS-6019,OCPBUGS-6020,OCPBUGS-2021,OCPBUGS-2022: Force bumps xstream (transitive dependency) version to 1.4.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,9 @@ FROM quay.io/openshift/origin-jenkins-agent-maven:4.11.0 AS builder
 WORKDIR /java/src/github.com/openshift/jenkins-client-plugin
 COPY . .
 USER 0
-RUN export PATH=/opt/rh/rh-maven35/root/usr/bin:$PATH && mvn clean package
+RUN mvn clean package
 
-FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.10.0
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.12.0
 #FROM quay.io/openshift/origin-jenkins:4.11.0
 RUN rm /opt/openshift/plugins/openshift-client.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-client-plugin/target/openshift-client.hpi /opt/openshift/plugins

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.289.1</jenkins.version>
+    <jenkins.version>2.387.1</jenkins.version>
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <enforcer.skip>true</enforcer.skip>
@@ -42,12 +42,6 @@
       <artifactId>command-launcher</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.main</groupId>
-      <artifactId>jenkins-core</artifactId>
-      <version>2.387.1</version>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>
@@ -58,11 +52,6 @@
         <version>26</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>1.4.20</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
       <artifactId>command-launcher</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+      <version>1.4.20</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.thoughtworks.xstream</groupId>
-      <artifactId>xstream</artifactId>
-      <version>1.4.20</version>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-core</artifactId>
+      <version>2.387.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -58,6 +58,11 @@
         <version>26</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>com.thoughtworks.xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <version>1.4.20</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.16</version>
+    <version>4.32</version>
     <relativePath />
   </parent>
 
@@ -22,8 +22,8 @@
     <spotbugs.failOnError>false</spotbugs.failOnError>
     <animal.sniffer.skip>true</animal.sniffer.skip>
     <enforcer.skip>true</enforcer.skip>
-    <java.level>8</java.level>
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+    <java.level>11</java.level>
+    <jenkins-test-harness.version>1952.v3a_b_0cd3f5a_03</jenkins-test-harness.version>
     <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>
     <findbugs.failOnError>false</findbugs.failOnError>
   </properties>
@@ -36,6 +36,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps</artifactId>
+      <version>3565.v4b_d9b_8c29a_b_3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -56,15 +57,35 @@
     </dependencies>
   </dependencyManagement>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <minimumJavaVersion>11</minimumJavaVersion>
+          <pluginFirstClassLoader>true</pluginFirstClassLoader>
+          <loggers>
+            <io.fabric8>${log.level}</io.fabric8>
+            <okhttp3>${log.level}</okhttp3>
+          </loggers>
+          <webApp>
+            <contextPath>/</contextPath>
+          </webApp>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <organization>
     <name>Red Hat, Inc</name>
-    <url>http://www.redhat.com</url>
+    <url>https://www.redhat.com</url>
   </organization>
 
   <licenses>
     <license>
       <name>Apache License</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
   <developers>
@@ -77,7 +98,7 @@
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
As per current `mvn dependency:tree`, the  `jenkins-core` is dependent on xstream-v1.4.16.
> [INFO] +- org.jenkins-ci.main:jenkins-core:jar:2.289.1:provided
> ...
> [INFO] |  +- com.thoughtworks.xstream:xstream:jar:1.4.16:provided
> [INFO] |  |  \- io.github.x-stream:mxparser:jar:1.2.1:provided

Bumping the xstream version to 1.4.20. (ref: https://github.com/x-stream/xstream/security/advisories/GHSA-j563-grx4-pjpv).