### PR TITLE
JKNS-572: Change jenkins baseline version from 2.426.2 to 2.440.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L -o maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.8.8/binarie
 RUN ./maven/bin/mvn --version && \
 	./maven/bin/mvn clean package
 
-FROM registry.ci.openshift.org/origin/4.16:jenkins
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.15.0
 RUN rm /opt/openshift/plugins/openshift-client.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-client-plugin/target/openshift-client.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-client.hpi /opt/openshift/plugins/openshift-client.jpi

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <revision>1.1.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.426.2</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <log.level>INFO</log.level>
   </properties>
 
@@ -84,41 +84,21 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.303.x -->
+      <!-- https://mvnrepository.com/artifact/io.jenkins.tools.bom/bom-2.440.x -->
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>2705.vf5c48c31285b_</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>3435.v238d66a_043fb_</version>
         <scope>import</scope>
         <type>pom</type>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
-      <version>1311.vcf0a_900b_37c2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>command-launcher</artifactId>
-      <version>100.v2f6722292ee8</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>script-security</artifactId>
-      <version>1313.v7a_6067dc7087</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-      <version>639.v6eca_cd8c04a_a_</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-cps</artifactId>
-      <version>3837.v305192405b_c0</version>
-    </dependency>
-  </dependencies>
+      </dependency>
+      <!-- Downgrade asm-api version from 9.7-33.x to 9.6-3.x to resolve compatibility issues with asm-util -->
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>asm-api</artifactId>
+        <version>9.6-3.v2e1fa_b_338cd7</version>
+      </dependency>
+    </dependencies>
   </dependencyManagement>
   <build>
     <plugins>


### PR DESCRIPTION
- [x] Update Jenkins baseline version to 2.440.3

- [x] Update Jenkins bom in dependency management section to reference 2.440.x release line.

- [x] Remove dependency version overrides as needed.