### PR TITLE
JKNS-457: Update Image for CI Testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -L -o maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.8.8/binarie
 RUN ./maven/bin/mvn --version && \
 	./maven/bin/mvn clean package
 
-FROM registry.ci.openshift.org/origin/4.16:jenkins
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0
 RUN rm /opt/openshift/plugins/openshift-client.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-client-plugin/target/openshift-client.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-client.hpi /opt/openshift/plugins/openshift-client.jpi


### PR DESCRIPTION
- [x] Update latest Jenkins image to debug CI test failure