### PR TITLE
JKNS-723: Bump jdk version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,9 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback. If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true,
   configurations: [
-    [platform: 'linux', jdk: 11],
-    [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
 ])


### PR DESCRIPTION
- Bump `jdk` version in Jenkinsfile
- Adds `forkCount` to run tests in parallel